### PR TITLE
Fixes missing virtual dtor for FeatureModelParser

### DIFF
--- a/include/vara/Feature/FeatureModelParser.h
+++ b/include/vara/Feature/FeatureModelParser.h
@@ -19,6 +19,8 @@ protected:
   explicit FeatureModelParser() = default;
 
 public:
+  virtual ~FeatureModelParser() = default;
+
   /// Build \a FeatureModel after parsing.
   ///
   /// \returns an instance of \a FeatureModel

--- a/lib/Feature/FeatureModelParser.cpp
+++ b/lib/Feature/FeatureModelParser.cpp
@@ -279,7 +279,7 @@ FeatureModelXmlParser::createDtd() {
       xmlFreeDtd);
   xmlCleanupParser();
   assert(Dtd && "Failed to parse DTD.");
-  return std::move(Dtd);
+  return Dtd;
 }
 
 std::unique_ptr<xmlDoc, void (*)(xmlDocPtr)> FeatureModelXmlParser::parseDoc() {
@@ -293,7 +293,7 @@ std::unique_ptr<xmlDoc, void (*)(xmlDocPtr)> FeatureModelXmlParser::parseDoc() {
   if (Doc && Ctxt->valid) {
     xmlValidateDtd(&Ctxt->vctxt, Doc.get(), createDtd().get());
     if (Ctxt->vctxt.valid) {
-      return std::move(Doc);
+      return Doc;
     } else {
       std::cerr << "Failed to validate DTD." << std::endl;
     }


### PR DESCRIPTION
Adds virtual dtor so sub classes be properly destroyed throught super
class ptrs. Furthermore, remove std::move to allow copy elision.