### PR TITLE
Location setter and comparison fixes

### DIFF
--- a/bindings/python/tests/feature/test_feature.py
+++ b/bindings/python/tests/feature/test_feature.py
@@ -136,6 +136,36 @@ class TestFeature(unittest.TestCase):
         self.assertEqual(test_feature_0.location.end.column_offset,
                          18)
 
+        test_feature_0.location = test_feature_0.location
+        self.assertTrue(test_feature_0.location)
+        self.assertEqual(test_feature_0.location.path, path)
+        self.assertEqual(test_feature_0.location.start.line_number,
+                         4)
+        self.assertEqual(
+            test_feature_0.location.start.column_offset, 2)
+        self.assertEqual(test_feature_0.location.end.line_number, 4)
+        self.assertEqual(test_feature_0.location.end.column_offset,
+                         18)
+        
+    def test_feature_location_self_assign(self):
+        """ Checks if a feature's location is mutable."""
+        path = "test"
+        start_lco = feature.LineColumnOffset(4, 2)
+        end_lco = feature.LineColumnOffset(4, 18)
+        loc = feature.Location(path, start_lco, end_lco)
+        test_feature_0 = feature.BinaryFeature("Test", False, loc)
+
+        test_feature_0.location = test_feature_0.location
+        self.assertTrue(test_feature_0.location)
+        self.assertEqual(test_feature_0.location.path, path)
+        self.assertEqual(test_feature_0.location.start.line_number,
+                         4)
+        self.assertEqual(
+            test_feature_0.location.start.column_offset, 2)
+        self.assertEqual(test_feature_0.location.end.line_number, 4)
+        self.assertEqual(test_feature_0.location.end.column_offset,
+                         18)
+        
 
 class TestBinaryFeature(unittest.TestCase):
     """ Test BinaryFeature functionality.  """

--- a/bindings/python/tests/feature/test_feature.py
+++ b/bindings/python/tests/feature/test_feature.py
@@ -136,17 +136,6 @@ class TestFeature(unittest.TestCase):
         self.assertEqual(test_feature_0.location.end.column_offset,
                          18)
 
-        test_feature_0.location = test_feature_0.location
-        self.assertTrue(test_feature_0.location)
-        self.assertEqual(test_feature_0.location.path, path)
-        self.assertEqual(test_feature_0.location.start.line_number,
-                         4)
-        self.assertEqual(
-            test_feature_0.location.start.column_offset, 2)
-        self.assertEqual(test_feature_0.location.end.line_number, 4)
-        self.assertEqual(test_feature_0.location.end.column_offset,
-                         18)
-        
     def test_feature_location_self_assign(self):
         """ Checks if a feature's location is mutable."""
         path = "test"
@@ -165,7 +154,7 @@ class TestFeature(unittest.TestCase):
         self.assertEqual(test_feature_0.location.end.line_number, 4)
         self.assertEqual(test_feature_0.location.end.column_offset,
                          18)
-        
+
 
 class TestBinaryFeature(unittest.TestCase):
     """ Test BinaryFeature functionality.  """

--- a/bindings/python/vara-feature/pybind_FeatureSourceRange.cpp
+++ b/bindings/python/vara-feature/pybind_FeatureSourceRange.cpp
@@ -49,7 +49,12 @@ void init_feature_location_module(py::module &M) {
       .def_property_readonly(
           "end", &vf::FeatureSourceRange::getEnd,
           R"pbdoc(Get the end `LineColumnOffset` of this `Location`.)pbdoc")
-      .def("__str__", &vf::FeatureSourceRange::toString);
+      .def("__str__", &vf::FeatureSourceRange::toString)
+      .def("__eq__", [](const vf::FeatureSourceRange &Self,
+                        const vf::FeatureSourceRange *Other) {
+        if (!Other) return false;
+        return Self == *Other;
+      }, py::arg("Other").none(true));
 
   py::class_<vf::FeatureSourceRange::FeatureSourceLocation>(M,
                                                             "LineColumnOffset")
@@ -63,9 +68,9 @@ void init_feature_location_module(py::module &M) {
           &vf::FeatureSourceRange::FeatureSourceLocation::getColumnOffset,
           &vf::FeatureSourceRange::FeatureSourceLocation::setColumnOffset)
       .def("__str__", &vf::FeatureSourceRange::FeatureSourceLocation::toString)
-      .def("__eq__",
-           [](const vf::FeatureSourceRange::FeatureSourceLocation &Self,
-              const vf::FeatureSourceRange::FeatureSourceLocation &Other) {
-             return Self == Other;
-           });
+      .def("__eq__", [](const vf::FeatureSourceRange::FeatureSourceLocation &Self,
+                        const vf::FeatureSourceRange::FeatureSourceLocation *Other) {
+        if (!Other) return false;
+        return Self == *Other;
+      }, py::arg("Other").none(true));
 }

--- a/bindings/python/vara-feature/pybind_FeatureSourceRange.cpp
+++ b/bindings/python/vara-feature/pybind_FeatureSourceRange.cpp
@@ -50,11 +50,16 @@ void init_feature_location_module(py::module &M) {
           "end", &vf::FeatureSourceRange::getEnd,
           R"pbdoc(Get the end `LineColumnOffset` of this `Location`.)pbdoc")
       .def("__str__", &vf::FeatureSourceRange::toString)
-      .def("__eq__", [](const vf::FeatureSourceRange &Self,
-                        const vf::FeatureSourceRange *Other) {
-        if (!Other) return false;
-        return Self == *Other;
-      }, py::arg("Other").none(true));
+      .def(
+          "__eq__",
+          [](const vf::FeatureSourceRange &Self,
+             const vf::FeatureSourceRange *Other) {
+            if (!Other) {
+              return false;
+            }
+            return Self == *Other;
+          },
+          py::arg("Other").none(true));
 
   py::class_<vf::FeatureSourceRange::FeatureSourceLocation>(M,
                                                             "LineColumnOffset")
@@ -68,9 +73,14 @@ void init_feature_location_module(py::module &M) {
           &vf::FeatureSourceRange::FeatureSourceLocation::getColumnOffset,
           &vf::FeatureSourceRange::FeatureSourceLocation::setColumnOffset)
       .def("__str__", &vf::FeatureSourceRange::FeatureSourceLocation::toString)
-      .def("__eq__", [](const vf::FeatureSourceRange::FeatureSourceLocation &Self,
-                        const vf::FeatureSourceRange::FeatureSourceLocation *Other) {
-        if (!Other) return false;
-        return Self == *Other;
-      }, py::arg("Other").none(true));
+      .def(
+          "__eq__",
+          [](const vf::FeatureSourceRange::FeatureSourceLocation &Self,
+             const vf::FeatureSourceRange::FeatureSourceLocation *Other) {
+            if (!Other) {
+              return false;
+            }
+            return Self == *Other;
+          },
+          py::arg("Other").none(true));
 }

--- a/include/vara/Feature/Feature.h
+++ b/include/vara/Feature/Feature.h
@@ -159,8 +159,8 @@ public:
   [[nodiscard]] FeatureSourceRange *getFeatureSourceRange() {
     return Source.has_value() ? &Source.value() : nullptr;
   }
-  void setFeatureSourceRange(FeatureSourceRange FeatureSR) {
-    Source = std::move(FeatureSR);
+  void setFeatureSourceRange(FeatureSourceRange &FeatureSR) {
+    Source = FeatureSourceRange(FeatureSR);
   }
 
   //===--------------------------------------------------------------------===//

--- a/include/vara/Feature/Feature.h
+++ b/include/vara/Feature/Feature.h
@@ -159,8 +159,8 @@ public:
   [[nodiscard]] FeatureSourceRange *getFeatureSourceRange() {
     return Source.has_value() ? &Source.value() : nullptr;
   }
-  void setFeatureSourceRange(FeatureSourceRange &FeatureSR) {
-    Source = FeatureSourceRange(FeatureSR);
+  void setFeatureSourceRange(FeatureSourceRange FeatureSR) {
+    Source = std::move(FeatureSR);
   }
 
   //===--------------------------------------------------------------------===//

--- a/include/vara/Feature/FeatureSourceRange.h
+++ b/include/vara/Feature/FeatureSourceRange.h
@@ -81,7 +81,6 @@ public:
   [[nodiscard]] bool hasEnd() const { return End.has_value(); }
   [[nodiscard]] FeatureSourceLocation *getEnd() {
     return End.has_value() ? &End.value() : nullptr;
-    ;
   }
 
   [[nodiscard]] std::string toString() const {
@@ -94,6 +93,14 @@ public:
       StrS << "-" << End->toString();
     }
     return StrS.str();
+  }
+
+  inline bool operator==(const FeatureSourceRange &Other) const {
+    return Path == Other.Path and Start == Other.Start and End == Other.End;
+  }
+
+  inline bool operator!=(const FeatureSourceRange &Other) const {
+    return !(*this == Other);
   }
 
 private:

--- a/unittests/Feature/Feature.cpp
+++ b/unittests/Feature/Feature.cpp
@@ -41,4 +41,35 @@ TEST(Feature, locationSetters) {
   EXPECT_EQ(TestLCO.getFeatureSourceRange()->getEnd()->getColumnOffset(), 18);
 }
 
+TEST(Feature, locationSetter) {
+    FeatureSourceRange::FeatureSourceLocation Start(3, 4);
+    FeatureSourceRange::FeatureSourceLocation End(3, 20);
+    BinaryFeature TestLCO("TEST", false, FeatureSourceRange("path", Start, End));
+
+    Start = FeatureSourceRange::FeatureSourceLocation(4, 4);
+    End = FeatureSourceRange::FeatureSourceLocation(5,20);
+    FeatureSourceRange otherLocation("path2", Start, End);
+    TestLCO.setFeatureSourceRange(otherLocation);
+
+    EXPECT_EQ(TestLCO.getFeatureSourceRange()->getPath(), "path2");
+    EXPECT_EQ(TestLCO.getFeatureSourceRange()->getStart()->getLineNumber(), 4);
+    EXPECT_EQ(TestLCO.getFeatureSourceRange()->getStart()->getColumnOffset(), 4);
+    EXPECT_EQ(TestLCO.getFeatureSourceRange()->getEnd()->getLineNumber(), 5);
+    EXPECT_EQ(TestLCO.getFeatureSourceRange()->getEnd()->getColumnOffset(), 20);
+  }
+
+TEST(Feature, locationSetOnOwnLocation) {
+    FeatureSourceRange::FeatureSourceLocation Start(3, 4);
+    FeatureSourceRange::FeatureSourceLocation End(3, 20);
+    BinaryFeature TestLCO("TEST", false, FeatureSourceRange("path", Start, End));
+
+    TestLCO.setFeatureSourceRange(*(TestLCO.getFeatureSourceRange()));
+    EXPECT_EQ(TestLCO.getFeatureSourceRange()->getPath(), "path");
+    EXPECT_EQ(TestLCO.getFeatureSourceRange()->getStart()->getLineNumber(), 3);
+    EXPECT_EQ(TestLCO.getFeatureSourceRange()->getStart()->getColumnOffset(), 4);
+    EXPECT_EQ(TestLCO.getFeatureSourceRange()->getEnd()->getLineNumber(), 3);
+    EXPECT_EQ(TestLCO.getFeatureSourceRange()->getEnd()->getColumnOffset(), 20);
+  }
+
+
 } // namespace vara::feature

--- a/unittests/Feature/Feature.cpp
+++ b/unittests/Feature/Feature.cpp
@@ -48,8 +48,8 @@ TEST(Feature, locationSetter) {
 
     Start = FeatureSourceRange::FeatureSourceLocation(4, 4);
     End = FeatureSourceRange::FeatureSourceLocation(5,20);
-    FeatureSourceRange otherLocation("path2", Start, End);
-    TestLCO.setFeatureSourceRange(otherLocation);
+    FeatureSourceRange OtherLocation("path2", Start, End);
+    TestLCO.setFeatureSourceRange(OtherLocation);
 
     EXPECT_EQ(TestLCO.getFeatureSourceRange()->getPath(), "path2");
     EXPECT_EQ(TestLCO.getFeatureSourceRange()->getStart()->getLineNumber(), 4);

--- a/unittests/Feature/FeatureSourceRange.cpp
+++ b/unittests/Feature/FeatureSourceRange.cpp
@@ -75,11 +75,11 @@ TEST(FeatureSourceRange, onlyEnd) {
 }
 
 TEST(FeatureSourceRange, equality) {
-  auto Path1 = "path1";
+  const auto *Path1 = "path1";
   auto Fsl1start = FeatureSourceRange::FeatureSourceLocation(1,2);
   auto Fsl1end = FeatureSourceRange::FeatureSourceLocation(1, 20);
   auto L1 = FeatureSourceRange(Path1, Fsl1start, Fsl1end);
-  auto Path2 = "path2";
+  const auto *Path2 = "path2";
   auto Fsl2start = FeatureSourceRange::FeatureSourceLocation(1, 2);
   auto Fsl2end = FeatureSourceRange::FeatureSourceLocation(1, 20);
   auto L2 = FeatureSourceRange(Path2, Fsl2start, Fsl2end);

--- a/unittests/Feature/FeatureSourceRange.cpp
+++ b/unittests/Feature/FeatureSourceRange.cpp
@@ -73,4 +73,19 @@ TEST(FeatureSourceRange, onlyEnd) {
   EXPECT_FALSE(L.hasStart());
   EXPECT_TRUE(L.hasEnd());
 }
+
+TEST(FeatureSourceRange, equality) {
+  auto Path1 = "path1";
+  auto Fsl1start = FeatureSourceRange::FeatureSourceLocation(1,2);
+  auto Fsl1end = FeatureSourceRange::FeatureSourceLocation(1, 20);
+  auto L1 = FeatureSourceRange(Path1, Fsl1start, Fsl1end);
+  auto Path2 = "path2";
+  auto Fsl2start = FeatureSourceRange::FeatureSourceLocation(1, 2);
+  auto Fsl2end = FeatureSourceRange::FeatureSourceLocation(1, 20);
+  auto L2 = FeatureSourceRange(Path2, Fsl2start, Fsl2end);
+  EXPECT_NE(L1, L2);
+
+  L2.setPath(Path1);
+  EXPECT_EQ(L1, L2);
+}
 } // namespace vara::feature


### PR DESCRIPTION
Setting a location now copies the location and location equality now also requires an equal path.