### PR TITLE
Fix parser bug and add tests

### DIFF
--- a/lib/Feature/FeatureModel.cpp
+++ b/lib/Feature/FeatureModel.cpp
@@ -180,8 +180,7 @@ void FeatureModelBuilder::detectXMLAlternatives() {
         llvm::SmallSet<Feature *, 3> Xor;
         Xor.insert(F);
         for (const auto &Name : Frontier) {
-          if (auto *E =
-                  llvm::dyn_cast<Feature>(Features[Frontier.back()].get());
+          if (auto *E = llvm::dyn_cast<Feature>(Features[Name].get());
               E && !E->isOptional()) {
             if (std::all_of(Xor.begin(), Xor.end(), [E](const auto *F) {
                   return isSimpleMutex(F, E);

--- a/unittests/Feature/CMakeLists.txt
+++ b/unittests/Feature/CMakeLists.txt
@@ -5,6 +5,7 @@ add_vara_unittest(VaRAFeatureTests
   FeatureSourceRange.cpp
   FeatureModel.cpp
   FeatureModelBuilder.cpp
+  FeatureModelParser.cpp
   FeatureModelWriter.cpp
   OrderedFeatureVector.cpp
   Relationship.cpp

--- a/unittests/Feature/FeatureModelBuilder.cpp
+++ b/unittests/Feature/FeatureModelBuilder.cpp
@@ -131,7 +131,7 @@ TEST(FeatureModelBuilder, addNumericFeatureRef) {
   EXPECT_TRUE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("aa")));
 }
 
-TEST(Relationship, detectXMLAlternativesSimple) {
+TEST(FeatureModelBuilder, detectXMLAlternativesSimple) {
   FeatureModelBuilder B;
   BinaryFeature AA("aa", false);
   BinaryFeature AB("ab", false);
@@ -162,7 +162,7 @@ TEST(Relationship, detectXMLAlternativesSimple) {
   EXPECT_TRUE(R->hasEdgeTo(*FM->getFeature("ab")));
 }
 
-TEST(Relationship, detectXMLAlternativesBroken) {
+TEST(FeatureModelBuilder, detectXMLAlternativesBroken) {
   FeatureModelBuilder B;
   BinaryFeature AA("aa", false);
   BinaryFeature AB("ab", false);
@@ -185,7 +185,7 @@ TEST(Relationship, detectXMLAlternativesBroken) {
   EXPECT_TRUE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ab")));
 }
 
-TEST(Relationship, detectXMLAlternativesOutOfOrder) {
+TEST(FeatureModelBuilder, detectXMLAlternativesOutOfOrder) {
   FeatureModelBuilder B;
   BinaryFeature AA("aa", false);
   BinaryFeature AB("ab", false);

--- a/unittests/Feature/FeatureModelBuilder.cpp
+++ b/unittests/Feature/FeatureModelBuilder.cpp
@@ -152,14 +152,17 @@ TEST(FeatureModelBuilder, detectXMLAlternativesSimple) {
 
   auto FM = B.buildFeatureModel();
   assert(FM);
-  auto *R = llvm::dyn_cast<Relationship>(*FM->getFeature("a")->begin());
-  assert(R);
 
   EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("aa")));
   EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ab")));
-  EXPECT_TRUE(R->getKind() == Relationship::RelationshipKind::RK_ALTERNATIVE);
-  EXPECT_TRUE(R->hasEdgeTo(*FM->getFeature("aa")));
-  EXPECT_TRUE(R->hasEdgeTo(*FM->getFeature("ab")));
+  if (auto *R = llvm::dyn_cast<Relationship>(*FM->getFeature("a")->begin());
+      R) {
+    EXPECT_TRUE(R->getKind() == Relationship::RelationshipKind::RK_ALTERNATIVE);
+    EXPECT_TRUE(R->hasEdgeTo(*FM->getFeature("aa")));
+    EXPECT_TRUE(R->hasEdgeTo(*FM->getFeature("ab")));
+  } else {
+    FAIL();
+  }
 }
 
 TEST(FeatureModelBuilder, detectXMLAlternativesBroken) {

--- a/unittests/Feature/FeatureModelBuilder.cpp
+++ b/unittests/Feature/FeatureModelBuilder.cpp
@@ -120,8 +120,7 @@ TEST(FeatureModelBuilder, addNumericFeatureRef) {
   BinaryFeature AA("aa");
   auto CS = Feature::NodeSetType();
   CS.insert(&AA);
-  NumericFeature A("a", std::vector<int>{1, 2, 3}, false, {}, nullptr,
-                   CS);
+  NumericFeature A("a", std::vector<int>{1, 2, 3}, false, {}, nullptr, CS);
 
   B.addFeature(AA);
   B.addParent("aa", "a")->addFeature(A);
@@ -131,4 +130,97 @@ TEST(FeatureModelBuilder, addNumericFeatureRef) {
   EXPECT_EQ(FM->getFeature("a")->getKind(), Feature::FeatureKind::FK_NUMERIC);
   EXPECT_TRUE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("aa")));
 }
+
+TEST(Relationship, detectXMLAlternativesSimple) {
+  FeatureModelBuilder B;
+  BinaryFeature AA("aa", false);
+  BinaryFeature AB("ab", false);
+  auto CS = Feature::NodeSetType();
+  CS.insert(&AA);
+  CS.insert(&AB);
+  BinaryFeature A("a", false, {}, nullptr, CS);
+  B.addFeature(A);
+  B.addParent("aa", "a")->addFeature(AA);
+  B.addParent("ab", "a")->addFeature(AB);
+
+  B.addConstraint(std::make_unique<ExcludesConstraint>(
+      std::make_unique<PrimaryFeatureConstraint>(&AA),
+      std::make_unique<PrimaryFeatureConstraint>(&AB)));
+  B.addConstraint(std::make_unique<ExcludesConstraint>(
+      std::make_unique<PrimaryFeatureConstraint>(&AB),
+      std::make_unique<PrimaryFeatureConstraint>(&AA)));
+
+  auto FM = B.buildFeatureModel();
+  assert(FM);
+  auto *R = llvm::dyn_cast<Relationship>(*FM->getFeature("a")->begin());
+  assert(R);
+
+  EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("aa")));
+  EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ab")));
+  EXPECT_TRUE(R->getKind() == Relationship::RelationshipKind::RK_ALTERNATIVE);
+  EXPECT_TRUE(R->hasEdgeTo(*FM->getFeature("aa")));
+  EXPECT_TRUE(R->hasEdgeTo(*FM->getFeature("ab")));
+}
+
+TEST(Relationship, detectXMLAlternativesBroken) {
+  FeatureModelBuilder B;
+  BinaryFeature AA("aa", false);
+  BinaryFeature AB("ab", false);
+  auto CS = Feature::NodeSetType();
+  CS.insert(&AA);
+  CS.insert(&AB);
+  BinaryFeature A("a", false, {}, nullptr, CS);
+  B.addFeature(A);
+  B.addParent("aa", "a")->addFeature(AA);
+  B.addParent("ab", "a")->addFeature(AB);
+
+  B.addConstraint(std::make_unique<ExcludesConstraint>(
+      std::make_unique<PrimaryFeatureConstraint>(&AA),
+      std::make_unique<PrimaryFeatureConstraint>(&AB)));
+
+  auto FM = B.buildFeatureModel();
+  assert(FM);
+
+  EXPECT_TRUE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("aa")));
+  EXPECT_TRUE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ab")));
+}
+
+TEST(Relationship, detectXMLAlternativesOutOfOrder) {
+  FeatureModelBuilder B;
+  BinaryFeature AA("aa", false);
+  BinaryFeature AB("ab", false);
+  BinaryFeature AC("ac", false);
+  BinaryFeature AD("ad", false);
+  BinaryFeature AE("ae", false);
+  auto CS = Feature::NodeSetType();
+  CS.insert(&AA);
+  CS.insert(&AB);
+  CS.insert(&AC);
+  CS.insert(&AD);
+  CS.insert(&AE);
+  BinaryFeature A("a", false, {}, nullptr, CS);
+  B.addFeature(A);
+  B.addParent("aa", "a")->addFeature(AA);
+  B.addParent("ab", "a")->addFeature(AB);
+  B.addParent("ac", "a")->addFeature(AC);
+  B.addParent("ad", "a")->addFeature(AD);
+  B.addParent("ae", "a")->addFeature(AE);
+
+  B.addConstraint(std::make_unique<ExcludesConstraint>(
+      std::make_unique<PrimaryFeatureConstraint>(&AB),
+      std::make_unique<PrimaryFeatureConstraint>(&AD)));
+  B.addConstraint(std::make_unique<ExcludesConstraint>(
+      std::make_unique<PrimaryFeatureConstraint>(&AD),
+      std::make_unique<PrimaryFeatureConstraint>(&AB)));
+
+  auto FM = B.buildFeatureModel();
+  assert(FM);
+
+  EXPECT_TRUE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("aa")));
+  EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ab")));
+  EXPECT_TRUE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ac")));
+  EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ad")));
+  EXPECT_TRUE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ae")));
+}
+
 } // namespace vara::feature

--- a/unittests/Feature/FeatureModelParser.cpp
+++ b/unittests/Feature/FeatureModelParser.cpp
@@ -12,10 +12,10 @@ TEST(FeatureModelParser, onlyChildren) {
       getTestResource("test_only_children.xml"));
   assert(FS);
 
-  auto FM = FeatureModelXmlParser(FS.get()->getBuffer().str());
+  auto P = FeatureModelXmlParser(FS.get()->getBuffer().str());
 
-  EXPECT_TRUE(FM.verifyFeatureModel());
-  EXPECT_TRUE(FM.buildFeatureModel());
+  EXPECT_TRUE(P.verifyFeatureModel());
+  EXPECT_TRUE(P.buildFeatureModel());
 }
 
 TEST(FeatureModelParser, onlyParents) {
@@ -23,10 +23,10 @@ TEST(FeatureModelParser, onlyParents) {
       getTestResource("test_only_parents.xml"));
   assert(FS);
 
-  auto FM = FeatureModelXmlParser(FS.get()->getBuffer().str());
+  auto P = FeatureModelXmlParser(FS.get()->getBuffer().str());
 
-  EXPECT_TRUE(FM.verifyFeatureModel());
-  EXPECT_TRUE(FM.buildFeatureModel());
+  EXPECT_TRUE(P.verifyFeatureModel());
+  EXPECT_TRUE(P.buildFeatureModel());
 }
 
 TEST(FeatureModelParser, outOfOrder) {
@@ -34,10 +34,10 @@ TEST(FeatureModelParser, outOfOrder) {
       getTestResource("test_out_of_order.xml"));
   assert(FS);
 
-  auto FM = FeatureModelXmlParser(FS.get()->getBuffer().str());
+  auto P = FeatureModelXmlParser(FS.get()->getBuffer().str());
 
-  EXPECT_TRUE(FM.verifyFeatureModel());
-  EXPECT_TRUE(FM.buildFeatureModel());
+  EXPECT_TRUE(P.verifyFeatureModel());
+  EXPECT_TRUE(P.buildFeatureModel());
 }
 
 } // namespace vara::feature

--- a/unittests/Feature/FeatureModelParser.cpp
+++ b/unittests/Feature/FeatureModelParser.cpp
@@ -1,0 +1,43 @@
+#include "vara/Feature/FeatureModelParser.h"
+
+#include "UnittestHelper.h"
+
+#include "llvm/Support/MemoryBuffer.h"
+#include "gtest/gtest.h"
+
+namespace vara::feature {
+
+TEST(FeatureModelParser, onlyChildren) {
+  auto FS = llvm::MemoryBuffer::getFileAsStream(
+      getTestResource("test_only_children.xml"));
+  assert(FS);
+
+  auto FM = FeatureModelXmlParser(FS.get()->getBuffer().str());
+
+  EXPECT_TRUE(FM.verifyFeatureModel());
+  EXPECT_TRUE(FM.buildFeatureModel());
+}
+
+TEST(FeatureModelParser, onlyParents) {
+  auto FS = llvm::MemoryBuffer::getFileAsStream(
+      getTestResource("test_only_parents.xml"));
+  assert(FS);
+
+  auto FM = FeatureModelXmlParser(FS.get()->getBuffer().str());
+
+  EXPECT_TRUE(FM.verifyFeatureModel());
+  EXPECT_TRUE(FM.buildFeatureModel());
+}
+
+TEST(FeatureModelParser, outOfOrder) {
+  auto FS = llvm::MemoryBuffer::getFileAsStream(
+      getTestResource("test_out_of_order.xml"));
+  assert(FS);
+
+  auto FM = FeatureModelXmlParser(FS.get()->getBuffer().str());
+
+  EXPECT_TRUE(FM.verifyFeatureModel());
+  EXPECT_TRUE(FM.buildFeatureModel());
+}
+
+} // namespace vara::feature

--- a/unittests/Feature/Relationship.cpp
+++ b/unittests/Feature/Relationship.cpp
@@ -12,8 +12,7 @@ TEST(Relationship, orTree) {
   auto CS = Feature::NodeSetType();
   CS.insert(&AA);
   CS.insert(&AB);
-  NumericFeature A("a", std::vector<int>{1, 2, 3}, false, {}, nullptr,
-                   CS);
+  BinaryFeature A("a", false, {}, nullptr, CS);
   B.addFeature(A);
   B.addParent("aa", "a")->addFeature(AA);
   B.addParent("ab", "a")->addFeature(AB);
@@ -39,8 +38,7 @@ TEST(Relationship, alternativeTree) {
   auto CS = Feature::NodeSetType();
   CS.insert(&AA);
   CS.insert(&AB);
-  NumericFeature A("a", std::vector<int>{1, 2, 3}, false, {}, nullptr,
-                   CS);
+  BinaryFeature A("a", false, {}, nullptr, CS);
   B.addFeature(A);
   B.addParent("aa", "a")->addFeature(AA);
   B.addParent("ab", "a")->addFeature(AB);
@@ -58,4 +56,63 @@ TEST(Relationship, alternativeTree) {
   EXPECT_TRUE(R->hasEdgeTo(*FM->getFeature("aa")));
   EXPECT_TRUE(R->hasEdgeTo(*FM->getFeature("ab")));
 }
+
+TEST(Relationship, outOfOrder) {
+  FeatureModelBuilder B;
+  BinaryFeature AA("aa");
+  BinaryFeature AB("ab");
+  BinaryFeature AC("ac");
+  BinaryFeature AD("ad");
+  BinaryFeature AE("ae");
+  auto CS = Feature::NodeSetType();
+  CS.insert(&AA);
+  CS.insert(&AB);
+  CS.insert(&AC);
+  CS.insert(&AD);
+  BinaryFeature A("a", false, {}, nullptr, CS);
+  B.addFeature(A);
+  B.addParent("aa", "a")->addFeature(AA);
+  B.addParent("ab", "a")->addFeature(AB);
+  B.addParent("ac", "a")->addFeature(AC);
+  B.addParent("ad", "a")->addFeature(AD);
+  B.addParent("ae", "a")->addFeature(AE);
+
+  B.emplaceRelationship(Relationship::RelationshipKind::RK_OR, {"ad", "ab"},
+                        "a");
+  auto FM = B.buildFeatureModel();
+  assert(FM);
+  auto *R = llvm::dyn_cast<Relationship>(*FM->getFeature("a")->begin());
+  assert(R);
+
+  EXPECT_TRUE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("aa")));
+  EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ab")));
+  EXPECT_TRUE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ac")));
+  EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ad")));
+  EXPECT_TRUE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ae")));
+  EXPECT_TRUE(R->getKind() == Relationship::RelationshipKind::RK_OR);
+  EXPECT_TRUE(R->hasEdgeTo(*FM->getFeature("ab")));
+  EXPECT_TRUE(R->hasEdgeTo(*FM->getFeature("ad")));
+}
+
+TEST(Relationship, diffParents) {
+  FeatureModelBuilder B;
+  BinaryFeature AA("aa");
+  BinaryFeature BA("ba");
+  auto CS = Feature::NodeSetType();
+  CS.insert(&AA);
+  auto BS = Feature::NodeSetType();
+  BS.insert(&BA);
+  BinaryFeature A("a", false, {}, nullptr, CS);
+  BinaryFeature C("b", false, {}, nullptr, BS);
+  B.addFeature(A);
+  B.addFeature(C);
+  B.addParent("aa", "a")->addFeature(AA);
+  B.addParent("ba", "b")->addFeature(BA);
+
+  B.emplaceRelationship(Relationship::RelationshipKind::RK_OR, {"ba", "aa"},
+                        "a");
+
+  EXPECT_FALSE(B.buildFeatureModel());
+}
+
 } // namespace vara::feature

--- a/unittests/Feature/Relationship.cpp
+++ b/unittests/Feature/Relationship.cpp
@@ -21,14 +21,17 @@ TEST(Relationship, orTree) {
                         "a");
   auto FM = B.buildFeatureModel();
   assert(FM);
-  auto *R = llvm::dyn_cast<Relationship>(*FM->getFeature("a")->begin());
-  assert(R);
 
   EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("aa")));
   EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ab")));
-  EXPECT_TRUE(R->getKind() == Relationship::RelationshipKind::RK_OR);
-  EXPECT_TRUE(R->hasEdgeTo(*FM->getFeature("aa")));
-  EXPECT_TRUE(R->hasEdgeTo(*FM->getFeature("ab")));
+  if (auto *R = llvm::dyn_cast<Relationship>(*FM->getFeature("a")->begin());
+      R) {
+    EXPECT_TRUE(R->getKind() == Relationship::RelationshipKind::RK_OR);
+    EXPECT_TRUE(R->hasEdgeTo(*FM->getFeature("aa")));
+    EXPECT_TRUE(R->hasEdgeTo(*FM->getFeature("ab")));
+  } else {
+    FAIL();
+  }
 }
 
 TEST(Relationship, alternativeTree) {
@@ -47,14 +50,17 @@ TEST(Relationship, alternativeTree) {
                         {"aa", "ab"}, "a");
   auto FM = B.buildFeatureModel();
   assert(FM);
-  auto *R = llvm::dyn_cast<Relationship>(*FM->getFeature("a")->begin());
-  assert(R);
 
   EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("aa")));
   EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ab")));
-  EXPECT_TRUE(R->getKind() == Relationship::RelationshipKind::RK_ALTERNATIVE);
-  EXPECT_TRUE(R->hasEdgeTo(*FM->getFeature("aa")));
-  EXPECT_TRUE(R->hasEdgeTo(*FM->getFeature("ab")));
+  if (auto *R = llvm::dyn_cast<Relationship>(*FM->getFeature("a")->begin());
+      R) {
+    EXPECT_TRUE(R->getKind() == Relationship::RelationshipKind::RK_ALTERNATIVE);
+    EXPECT_TRUE(R->hasEdgeTo(*FM->getFeature("aa")));
+    EXPECT_TRUE(R->hasEdgeTo(*FM->getFeature("ab")));
+  } else {
+    FAIL();
+  }
 }
 
 TEST(Relationship, outOfOrder) {

--- a/unittests/Feature/Relationship.cpp
+++ b/unittests/Feature/Relationship.cpp
@@ -69,6 +69,7 @@ TEST(Relationship, outOfOrder) {
   CS.insert(&AB);
   CS.insert(&AC);
   CS.insert(&AD);
+  CS.insert(&AE);
   BinaryFeature A("a", false, {}, nullptr, CS);
   B.addFeature(A);
   B.addParent("aa", "a")->addFeature(AA);
@@ -81,17 +82,12 @@ TEST(Relationship, outOfOrder) {
                         "a");
   auto FM = B.buildFeatureModel();
   assert(FM);
-  auto *R = llvm::dyn_cast<Relationship>(*FM->getFeature("a")->begin());
-  assert(R);
 
   EXPECT_TRUE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("aa")));
   EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ab")));
   EXPECT_TRUE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ac")));
   EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ad")));
   EXPECT_TRUE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ae")));
-  EXPECT_TRUE(R->getKind() == Relationship::RelationshipKind::RK_OR);
-  EXPECT_TRUE(R->hasEdgeTo(*FM->getFeature("ab")));
-  EXPECT_TRUE(R->hasEdgeTo(*FM->getFeature("ad")));
 }
 
 TEST(Relationship, diffParents) {

--- a/unittests/resources/CMakeLists.txt
+++ b/unittests/resources/CMakeLists.txt
@@ -10,6 +10,9 @@ set(FEATURE_LIB_TEST_FILES
   test.xml
   test_children.xml
   test_excludes.xml
+  test_only_children.xml
+  test_only_parents.xml
+  test_out_of_order.xml
   )
 
 foreach(file_name ${FEATURE_LIB_TEST_FILES})

--- a/unittests/resources/test_only_children.xml
+++ b/unittests/resources/test_only_children.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE vm SYSTEM "vm.dtd">
+<vm name="Children" root="test">
+  <binaryOptions>
+    <configurationOption>
+      <name>root</name>
+      <children>
+        <options>A</options>
+        <options>B</options>
+        <options>C</options>
+      </children>
+      <optional>False</optional>
+    </configurationOption>
+    <configurationOption>
+      <name>A</name>
+      <optional>True</optional>
+    </configurationOption>
+    <configurationOption>
+      <name>B</name>
+      <optional>True</optional>
+    </configurationOption>
+    <configurationOption>
+      <name>C</name>
+      <children>
+        <options>CA</options>
+        <options>CB</options>
+        <options>CC</options>
+      </children>
+      <optional>True</optional>
+    </configurationOption>
+    <configurationOption>
+      <name>CA</name>
+      <optional>True</optional>
+    </configurationOption>
+    <configurationOption>
+      <name>CB</name>
+      <optional>True</optional>
+    </configurationOption>
+    <configurationOption>
+      <name>CC</name>
+      <optional>True</optional>
+    </configurationOption>
+  </binaryOptions>
+  <numericOptions/>
+  <booleanConstraints/>
+</vm>

--- a/unittests/resources/test_only_parents.xml
+++ b/unittests/resources/test_only_parents.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE vm SYSTEM "vm.dtd">
+<vm name="Children" root="test">
+  <binaryOptions>
+    <configurationOption>
+      <name>root</name>
+      <optional>False</optional>
+    </configurationOption>
+    <configurationOption>
+      <name>A</name>
+      <parent>root</parent>
+      <optional>True</optional>
+    </configurationOption>
+    <configurationOption>
+      <name>B</name>
+      <parent>root</parent>
+      <optional>True</optional>
+    </configurationOption>
+    <configurationOption>
+      <name>C</name>
+      <parent>root</parent>
+      <optional>True</optional>
+    </configurationOption>
+    <configurationOption>
+      <name>CA</name>
+      <parent>C</parent>
+      <optional>True</optional>
+    </configurationOption>
+    <configurationOption>
+      <name>CB</name>
+      <parent>C</parent>
+      <optional>True</optional>
+    </configurationOption>
+    <configurationOption>
+      <name>CC</name>
+      <parent>C</parent>
+      <optional>True</optional>
+    </configurationOption>
+  </binaryOptions>
+  <numericOptions/>
+  <booleanConstraints/>
+</vm>

--- a/unittests/resources/test_out_of_order.xml
+++ b/unittests/resources/test_out_of_order.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE vm SYSTEM "vm.dtd">
+<vm name="Children" root="test">
+  <binaryOptions>
+    <configurationOption>
+      <name>CB</name>
+      <parent>C</parent>
+      <optional>True</optional>
+    </configurationOption>
+    <configurationOption>
+      <name>A</name>
+      <parent>root</parent>
+      <optional>True</optional>
+    </configurationOption>
+    <configurationOption>
+      <name>CA</name>
+      <parent>C</parent>
+      <optional>True</optional>
+    </configurationOption>
+    <configurationOption>
+      <name>root</name>
+      <children>
+        <options>A</options>
+        <options>B</options>
+        <options>C</options>
+      </children>
+      <optional>False</optional>
+    </configurationOption>
+    <configurationOption>
+      <name>CC</name>
+      <parent>C</parent>
+      <optional>True</optional>
+    </configurationOption>
+    <configurationOption>
+      <name>B</name>
+      <parent>root</parent>
+      <optional>True</optional>
+    </configurationOption>
+    <configurationOption>
+      <name>C</name>
+      <parent>root</parent>
+      <children>
+        <options>CA</options>
+        <options>CB</options>
+        <options>CC</options>
+      </children>
+      <optional>True</optional>
+    </configurationOption>
+  </binaryOptions>
+  <numericOptions/>
+  <booleanConstraints/>
+</vm>


### PR DESCRIPTION
Fix bug in builder and extend parsing of XML with children.
Add tests for different corner cases.

- [x] Adds parsing of children in XML (was missing)
  - [x] Add related tests with XML input
- [x] Test some corner cases for `Relationship`
- [x] Fix bug in alternative detection
  - [x] Add test for corrected behavior
- [x] Fix `clang-tidy` for test files in Release (possible initialized nullptr)
- [x] Add comment explaining, that DTD guarantees `name` as first element of `configurationOption` -- so the algorithm works

related se-passau/VaRA#635