### PR TITLE
Add Modifications and RootFeature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ compile_commands.json
 vara_feature.egg-info
 dist/
 .mypy_cache/
+venv/

--- a/bindings/python/tests/feature/test_feature.py
+++ b/bindings/python/tests/feature/test_feature.py
@@ -27,34 +27,7 @@ class TestFeature(unittest.TestCase):
     def test_is_root(self):
         """ Checks if a feature is root if it has no parents. """
         test_feature = feature.BinaryFeature("root", False)
-        self.assertTrue(test_feature.is_root())
-
-    def test_iter_children(self):
-        """ Checks if we can iterate over a features children. """
-        test_feature_1 = feature.BinaryFeature("a", False)
-        test_feature_2 = feature.BinaryFeature("b", True)
-
-        root_feature = feature.BinaryFeature("root", False,
-                                             [feature.Location("")], None,
-                                             [test_feature_1,
-                                              test_feature_2])
-
-        self.assertEqual(set(iter(root_feature)),
-                         set(root_feature.children()))
-        self.assertEqual({test_feature_1, test_feature_2},
-                         set(root_feature.children()))
-        self.assertTrue(root_feature.is_child(test_feature_1))
-
-    def test_parent(self):
-        """ Checks if we can iterate over a features children. """
-        test_feature_1 = feature.BinaryFeature("a", False)
-        test_feature_2 = feature.BinaryFeature("aa", True, [feature.Location("")],
-                                               test_feature_1)
-
-        self.assertFalse(test_feature_2.is_root())
-        self.assertEqual(test_feature_1,
-                         test_feature_2.parent())
-        self.assertTrue(test_feature_2.is_parent(test_feature_1))
+        self.assertFalse(test_feature.has_parent())
 
     def test_feature_equal(self):
         """ Checks if Feature equality comparison operator is correctly

--- a/bindings/python/tests/feature/test_feature.py
+++ b/bindings/python/tests/feature/test_feature.py
@@ -24,10 +24,15 @@ class TestFeature(unittest.TestCase):
         test_feature = feature.BinaryFeature("Foo", False)
         self.assertFalse(test_feature.is_optional())
 
-    def test_is_root(self):
+    def test_root(self):
+        """ Checks if a feature is root. """
+        test_feature = feature.RootFeature("a")
+        self.assertTrue(test_feature.is_root())
+
+    def test_false_root(self):
         """ Checks if a feature is root if it has no parents. """
-        test_feature = feature.BinaryFeature("root", False)
-        self.assertFalse(test_feature.has_parent())
+        test_feature = feature.BinaryFeature("a", False)
+        self.assertFalse(test_feature.is_root())
 
     def test_feature_equal(self):
         """ Checks if Feature equality comparison operator is correctly

--- a/bindings/python/tests/feature_model/test_feature_model.py
+++ b/bindings/python/tests/feature_model/test_feature_model.py
@@ -54,6 +54,21 @@ class TestFeatureModel(unittest.TestCase):
         self.assertEqual(next(fm_iter).name.str(), "N")
         self.assertEqual(next(fm_iter).name.str(), "C")
 
+    def test_parent(self):
+        """ Checks if we can access a features parent. """
+        test_feature_root = self.fm.get_feature("root")
+        test_feature_a = self.fm.get_feature("A")
+        test_feature_b = self.fm.get_feature("B")
+
+        self.assertTrue(test_feature_a.has_parent())
+        self.assertTrue(test_feature_b.has_parent())
+        self.assertEqual(test_feature_root,
+                         test_feature_a.parent())
+        self.assertEqual(test_feature_a.parent(),
+                         test_feature_b.parent())
+        self.assertTrue(test_feature_a.is_parent(test_feature_root))
+        self.assertTrue(test_feature_b.is_parent(test_feature_root))
+
     def test_iter_children(self):
         """ Checks if we can iterate over a features children. """
         test_feature_root = self.fm.get_feature("root")

--- a/bindings/python/tests/feature_model/test_feature_model.py
+++ b/bindings/python/tests/feature_model/test_feature_model.py
@@ -65,6 +65,6 @@ class TestFeatureModel(unittest.TestCase):
                          set(test_feature_root.children()))
         self.assertEqual({test_feature_a, test_feature_b, test_feature_c},
                          set(test_feature_root.children()))
-        self.assertTrue(test_feature_root.has_child(test_feature_a))
-        self.assertTrue(test_feature_root.has_child(test_feature_b))
-        self.assertTrue(test_feature_root.has_child(test_feature_c))
+        self.assertTrue(test_feature_root.is_child(test_feature_a))
+        self.assertTrue(test_feature_root.is_child(test_feature_b))
+        self.assertTrue(test_feature_root.is_child(test_feature_c))

--- a/bindings/python/tests/feature_model/test_feature_model.py
+++ b/bindings/python/tests/feature_model/test_feature_model.py
@@ -16,6 +16,7 @@ class TestFeatureModel(unittest.TestCase):
     """
     Check of our generated FeatureModel binding correctly work.
     """
+
     @classmethod
     def setUpClass(cls):
         """Parse and load a FeatureModel for testing."""
@@ -52,3 +53,18 @@ class TestFeatureModel(unittest.TestCase):
         self.assertEqual(next(fm_iter).name.str(), "B")
         self.assertEqual(next(fm_iter).name.str(), "N")
         self.assertEqual(next(fm_iter).name.str(), "C")
+
+    def test_iter_children(self):
+        """ Checks if we can iterate over a features children. """
+        test_feature_root = self.fm.get_feature("root")
+        test_feature_a = self.fm.get_feature("A")
+        test_feature_b = self.fm.get_feature("B")
+        test_feature_c = self.fm.get_feature("C")
+
+        self.assertEqual(set(iter(test_feature_root)),
+                         set(test_feature_root.children()))
+        self.assertEqual({test_feature_a, test_feature_b, test_feature_c},
+                         set(test_feature_root.children()))
+        self.assertTrue(test_feature_root.has_child(test_feature_a))
+        self.assertTrue(test_feature_root.has_child(test_feature_b))
+        self.assertTrue(test_feature_root.has_child(test_feature_c))

--- a/bindings/python/tests/feature_model/test_feature_model.py
+++ b/bindings/python/tests/feature_model/test_feature_model.py
@@ -60,8 +60,8 @@ class TestFeatureModel(unittest.TestCase):
         test_feature_a = self.fm.get_feature("A")
         test_feature_b = self.fm.get_feature("B")
 
-        self.assertTrue(test_feature_a.has_parent())
-        self.assertTrue(test_feature_b.has_parent())
+        self.assertFalse(test_feature_a.is_root())
+        self.assertFalse(test_feature_b.is_root())
         self.assertEqual(test_feature_root,
                          test_feature_a.parent())
         self.assertEqual(test_feature_a.parent(),

--- a/bindings/python/vara-feature/pybind_Feature.cpp
+++ b/bindings/python/vara-feature/pybind_Feature.cpp
@@ -99,9 +99,17 @@ void init_feature_module_numeric_feature(py::module &M) {
           R"pbdoc(Returns the string representation of a NumericFeature.)pbdoc");
 }
 
+void init_feature_module_root_feature(py::module &M) {
+  py::class_<vf::RootFeature, vf::Feature>(M, "RootFeature")
+      .def(py::init<std::string>())
+      .def("to_string", &vf::RootFeature::toString,
+           R"pbdoc(Returns the string representation of a RootFeature.)pbdoc");
+}
+
 void init_feature_module(py::module &M) {
   init_feature_module_feature_tree_node(M);
   init_feature_module_feature(M);
   init_feature_module_binary_feature(M);
   init_feature_module_numeric_feature(M);
+  init_feature_module_root_feature(M);
 }

--- a/bindings/python/vara-feature/pybind_Feature.cpp
+++ b/bindings/python/vara-feature/pybind_Feature.cpp
@@ -31,10 +31,6 @@ void init_feature_module_feature_tree_node(py::module &M) {
 
       //===----------------------------------------------------------------===//
       // Parent
-      .def(
-          "has_parent",
-          [](vf::FeatureTreeNode &F) { return F.getParent() != nullptr; },
-          R"pbdoc(`True` if this is not the root of a `FeatureModel`.)pbdoc")
       .def("parent", &vf::FeatureTreeNode::getParent,
            py::return_value_policy::reference, R"pbdoc(Parent feature)pbdoc")
       .def("is_parent", &vf::FeatureTreeNode::hasEdgeFrom,
@@ -46,6 +42,10 @@ void init_feature_module_feature(py::module &M) {
       .def("__hash__", &vf::Feature::hash)
       .def_property_readonly("name", &vf::Feature::getName,
                              R"pbdoc(The name of the feature.)pbdoc")
+      .def(
+          "is_root",
+          [](vf::Feature &F) { return llvm::isa<vf::RootFeature>(F); },
+          R"pbdoc(`True` if this is the root of a `FeatureModel`.)pbdoc")
       .def("is_optional", &vf::Feature::isOptional,
            R"pbdoc(`True` if the feature is optional.)pbdoc")
       .def_property_readonly(

--- a/bindings/python/vara-feature/pybind_Feature.cpp
+++ b/bindings/python/vara-feature/pybind_Feature.cpp
@@ -26,13 +26,14 @@ void init_feature_module_feature_tree_node(py::module &M) {
             return py::make_iterator(F.begin(), F.end());
           },
           py::keep_alive<0, 1>())
-      .def("has_child", &vf::FeatureTreeNode::hasEdgeTo,
+      .def("is_child", &vf::FeatureTreeNode::hasEdgeTo,
            R"pbdoc(Checks if a node is a child of this one.)pbdoc")
 
       //===----------------------------------------------------------------===//
       // Parent
       .def(
-          "has_parent", [](vf::FeatureTreeNode &F) { return F.getParent(); },
+          "has_parent",
+          [](vf::FeatureTreeNode &F) { return F.getParent() != nullptr; },
           R"pbdoc(`True` if this is not the root of a `FeatureModel`.)pbdoc")
       .def("parent", &vf::FeatureTreeNode::getParent,
            py::return_value_policy::reference, R"pbdoc(Parent feature)pbdoc")

--- a/bindings/python/vara-feature/pybind_Feature.cpp
+++ b/bindings/python/vara-feature/pybind_Feature.cpp
@@ -44,7 +44,7 @@ void init_feature_module_feature(py::module &M) {
                              R"pbdoc(The name of the feature.)pbdoc")
       .def(
           "is_root",
-          [](vf::Feature &F) { return llvm::isa<vf::RootFeature>(F); },
+          [](const vf::Feature &F) { return llvm::isa<vf::RootFeature>(F); },
           R"pbdoc(`True` if this is the root of a `FeatureModel`.)pbdoc")
       .def("is_optional", &vf::Feature::isOptional,
            R"pbdoc(`True` if the feature is optional.)pbdoc")

--- a/bindings/python/vara-feature/pybind_Feature.cpp
+++ b/bindings/python/vara-feature/pybind_Feature.cpp
@@ -12,9 +12,6 @@ namespace py = pybind11;
 
 void init_feature_module_feature_tree_node(py::module &M) {
   py::class_<vf::FeatureTreeNode>(M, "FeatureTreeNode")
-      .def("is_root", &vf::FeatureTreeNode::isRoot,
-           R"pbdoc(`True` if this is the root of a `FeatureModel`.)pbdoc")
-
       //===----------------------------------------------------------------===//
       // Children
       .def(
@@ -29,11 +26,14 @@ void init_feature_module_feature_tree_node(py::module &M) {
             return py::make_iterator(F.begin(), F.end());
           },
           py::keep_alive<0, 1>())
-      .def("is_child", &vf::FeatureTreeNode::hasEdgeTo,
+      .def("has_child", &vf::FeatureTreeNode::hasEdgeTo,
            R"pbdoc(Checks if a node is a child of this one.)pbdoc")
 
       //===----------------------------------------------------------------===//
       // Parent
+      .def(
+          "has_parent", [](vf::FeatureTreeNode &F) { return F.getParent(); },
+          R"pbdoc(`True` if this is not the root of a `FeatureModel`.)pbdoc")
       .def("parent", &vf::FeatureTreeNode::getParent,
            py::return_value_policy::reference, R"pbdoc(Parent feature)pbdoc")
       .def("is_parent", &vf::FeatureTreeNode::hasEdgeFrom,
@@ -80,13 +80,6 @@ void init_feature_module_binary_feature(py::module &M) {
       .def(py::init<std::string, bool>())
       .def(py::init<std::string, bool,
                     std::vector<vara::feature::FeatureSourceRange>>())
-      .def(py::init<std::string, bool,
-                    std::vector<vara::feature::FeatureSourceRange>,
-                    vara::feature::Feature *>())
-      .def(py::init<std::string, bool,
-                    std::vector<vara::feature::FeatureSourceRange>,
-                    vara::feature::Feature *,
-                    std::vector<vara::feature::FeatureTreeNode *>>())
       .def(
           "to_string", &vf::BinaryFeature::toString,
           R"pbdoc(Returns the string representation of a BinaryFeature.)pbdoc");

--- a/bindings/python/vara-feature/pybind_FeatureModel.cpp
+++ b/bindings/python/vara-feature/pybind_FeatureModel.cpp
@@ -22,6 +22,12 @@ void init_feature_model_module(py::module &M) {
       .def("get_root", &vf::FeatureModel::getRoot,
            py::return_value_policy::reference,
            R"pbdoc(Returns the root Feature.)pbdoc")
+      .def(
+          "get_feature",
+          [](vf::FeatureModel &FM, const std::string &Name) {
+            return FM.getFeature(Name);
+          },
+          py::return_value_policy::reference, R"pbdoc(Returns Feature.)pbdoc")
       .def("size", &vf::FeatureModel::size,
            R"pbdoc(Returns the amount of Features in the Model.)pbdoc")
       .def(

--- a/include/vara/Feature/Feature.h
+++ b/include/vara/Feature/Feature.h
@@ -264,7 +264,7 @@ private:
 
 class RootFeature : public Feature {
 public:
-  RootFeature(string Name = "root")
+  explicit RootFeature(string Name = "root")
       : Feature(FeatureKind::FK_ROOT, std::move(Name), false, {}) {}
 
   static bool classof(const Feature *F) {

--- a/include/vara/Feature/Feature.h
+++ b/include/vara/Feature/Feature.h
@@ -181,14 +181,8 @@ public:
 
 protected:
   Feature(FeatureKind Kind, string Name, bool Opt,
-          std::vector<FeatureSourceRange> Locations, FeatureTreeNode *Parent,
-          const NodeSetType &Children)
-      : FeatureTreeNode(NodeKind::NK_FEATURE, Parent, Children), Kind(Kind),
-        Name(std::move(Name)), Locations(std::move(Locations)), Opt(Opt) {}
-
-  Feature(FeatureKind Kind, string Name, bool Opt,
-          std::vector<FeatureSourceRange> Locations, FeatureTreeNode *Parent,
-          const std::vector<FeatureTreeNode *> &Children)
+          std::vector<FeatureSourceRange> Locations,
+          FeatureTreeNode *Parent = nullptr, const NodeSetType &Children = {})
       : FeatureTreeNode(NodeKind::NK_FEATURE, Parent, Children), Kind(Kind),
         Name(std::move(Name)), Locations(std::move(Locations)), Opt(Opt) {}
 
@@ -230,15 +224,8 @@ class BinaryFeature : public Feature {
 public:
   BinaryFeature(
       string Name, bool Opt = false,
-      std::vector<FeatureSourceRange> Loc = std::vector<FeatureSourceRange>(),
-      Feature *Parent = nullptr, const NodeSetType &Children = {})
-      : Feature(FeatureKind::FK_BINARY, std::move(Name), Opt, std::move(Loc),
-                Parent, Children) {}
-
-  BinaryFeature(const string &Name, bool Opt,
-                const std::vector<FeatureSourceRange> &Loc, Feature *Parent,
-                const std::vector<FeatureTreeNode *> &Children)
-      : Feature(FeatureKind::FK_BINARY, Name, Opt, Loc, Parent, Children) {}
+      std::vector<FeatureSourceRange> Loc = std::vector<FeatureSourceRange>())
+      : Feature(FeatureKind::FK_BINARY, std::move(Name), Opt, std::move(Loc)) {}
 
   [[nodiscard]] string toString() const override;
 
@@ -255,16 +242,8 @@ public:
 
   NumericFeature(
       string Name, ValuesVariantType Values, bool Opt = false,
-      std::vector<FeatureSourceRange> Loc = std::vector<FeatureSourceRange>(),
-      Feature *Parent = nullptr, const NodeSetType &Children = {})
-      : Feature(FeatureKind::FK_NUMERIC, std::move(Name), Opt, std::move(Loc),
-                Parent, Children),
-        Values(std::move(Values)) {}
-
-  NumericFeature(const string &Name, ValuesVariantType Values, bool Opt,
-                 const std::vector<FeatureSourceRange> &Loc, Feature *Parent,
-                 const std::vector<FeatureTreeNode *> &Children)
-      : Feature(FeatureKind::FK_NUMERIC, Name, Opt, Loc, Parent, Children),
+      std::vector<FeatureSourceRange> Loc = std::vector<FeatureSourceRange>())
+      : Feature(FeatureKind::FK_NUMERIC, std::move(Name), Opt, std::move(Loc)),
         Values(std::move(Values)) {}
 
   [[nodiscard]] ValuesVariantType getValues() const { return Values; }

--- a/include/vara/Feature/Feature.h
+++ b/include/vara/Feature/Feature.h
@@ -37,7 +37,7 @@ class Feature : public FeatureTreeNode {
   friend class detail::FeatureModelModification;
 
 public:
-  enum class FeatureKind { FK_BINARY, FK_NUMERIC, FK_UNKNOWN };
+  enum class FeatureKind { FK_BINARY, FK_NUMERIC, FK_ROOT, FK_UNKNOWN };
 
   Feature(std::string Name)
       : FeatureTreeNode(NodeKind::NK_FEATURE), Kind(FeatureKind::FK_UNKNOWN),
@@ -257,6 +257,21 @@ public:
 private:
   ValuesVariantType Values;
 };
+
+//===----------------------------------------------------------------------===//
+//                          RootFeature Class
+//===----------------------------------------------------------------------===//
+
+class RootFeature : public Feature {
+public:
+  RootFeature(string Name = "root")
+      : Feature(FeatureKind::FK_ROOT, std::move(Name), false, {}) {}
+
+  static bool classof(const Feature *F) {
+    return F->getKind() == FeatureKind::FK_ROOT;
+  }
+};
+
 } // namespace vara::feature
 
 #endif // VARA_FEATURE_FEATURE_H

--- a/include/vara/Feature/FeatureModel.h
+++ b/include/vara/Feature/FeatureModel.h
@@ -442,8 +442,7 @@ public:
 struct EveryFeatureRequiresParent {
   static bool check(FeatureModel &FM) {
     return std::all_of(FM.begin(), FM.end(), [](Feature *F) {
-      return llvm::isa<RootFeature>(F) ||
-             (F->getParent() && F->getParentFeature());
+      return llvm::isa<RootFeature>(F) || F->getParentFeature();
     });
   }
 };

--- a/include/vara/Feature/FeatureModel.h
+++ b/include/vara/Feature/FeatureModel.h
@@ -439,20 +439,23 @@ public:
 
 struct EveryFeatureRequiresParent {
   static bool check(FeatureModel &FM) {
-    return std::all_of(FM.begin(), FM.end(), [R = FM.getRoot()](Feature *F) {
-      return *R == *F || (F->getParent() != nullptr);
-    });
+    auto *Root = FM.getRoot();
+    return Root && std::all_of(FM.begin(), FM.end(), [Root](Feature *F) {
+             return (*Root == *F) || F->getParent();
+           });
   }
 };
 
 struct CheckFeatureParentChildRelationShip {
   static bool check(FeatureModel &FM) {
-    return std::all_of(FM.begin(), FM.end(), [R = FM.getRoot()](Feature *F) {
-      return *R == *F ||
-             // Every parent of a Feature needs to have the Feature as a child.
-             std::any_of(F->getParent()->begin(), F->getParent()->end(),
-                         [F](FeatureTreeNode *Child) { return F == Child; });
-    });
+    auto *Root = FM.getRoot();
+    return Root && std::all_of(FM.begin(), FM.end(), [Root](Feature *F) {
+             return (*Root == *F) ||
+                    // Every parent of a Feature needs to have that as a child.
+                    std::any_of(
+                        F->getParent()->begin(), F->getParent()->end(),
+                        [F](FeatureTreeNode *Child) { return F == Child; });
+           });
   }
 };
 

--- a/include/vara/Feature/FeatureModel.h
+++ b/include/vara/Feature/FeatureModel.h
@@ -166,7 +166,7 @@ public:
   template <typename FeatureTy, typename... Args,
             typename = typename std::enable_if_t<
                 std::is_base_of_v<Feature, FeatureTy>, int>>
-  Feature *makeFeature(const std::string &FeatureName, Args... FurtherArgs) {
+  FeatureTy *makeFeature(const std::string &FeatureName, Args... FurtherArgs) {
     if (!Features
              .try_emplace(FeatureName,
                           std::make_unique<FeatureTy>(
@@ -174,7 +174,7 @@ public:
              .second) {
       return nullptr;
     }
-    return Features[FeatureName].get();
+    return llvm::dyn_cast<FeatureTy>(Features[FeatureName].get());
   }
 
   FeatureModelBuilder *addEdge(const std::string &ParentName,
@@ -213,7 +213,10 @@ public:
     return this;
   }
 
-  FeatureModelBuilder *setRoot(const std::string &RootName = "root");
+  FeatureModelBuilder *setRootName(std::string Name) {
+    this->RootName = std::move(Name);
+    return this;
+  }
 
   /// Build \a FeatureModel.
   ///
@@ -245,6 +248,9 @@ private:
   llvm::StringMap<std::string> Parents;
   EdgeMapType Children;
   RelationshipEdgeType RelationshipEdges;
+  std::string RootName{"root"};
+
+  bool buildRoot();
 
   bool buildConstraints();
 

--- a/include/vara/Feature/FeatureModel.h
+++ b/include/vara/Feature/FeatureModel.h
@@ -58,10 +58,7 @@ public:
 
   [[nodiscard]] llvm::StringRef getCommit() const { return Commit; }
 
-  [[nodiscard]] Feature *getRoot() const {
-    assert(Root);
-    return Root;
-  }
+  [[nodiscard]] Feature *getRoot() const { return Root; }
 
   //===--------------------------------------------------------------------===//
   // Ordered feature iterator
@@ -164,13 +161,12 @@ public:
   ///
   /// \returns ptr to inserted \a Feature
   template <typename FeatureTy, typename... Args,
-            typename = typename std::enable_if_t<
-                std::is_base_of_v<Feature, FeatureTy>, int>>
-  FeatureTy *makeFeature(const std::string &FeatureName, Args... FurtherArgs) {
+            std::enable_if_t<std::is_base_of_v<Feature, FeatureTy>, int> = 0>
+  FeatureTy *makeFeature(std::string FeatureName, Args &&...FurtherArgs) {
     if (!Features
              .try_emplace(FeatureName,
                           std::make_unique<FeatureTy>(
-                              FeatureName, std::move(FurtherArgs)...))
+                              FeatureName, std::forward<Args>(FurtherArgs)...))
              .second) {
       return nullptr;
     }

--- a/include/vara/Feature/FeatureModel.h
+++ b/include/vara/Feature/FeatureModel.h
@@ -456,7 +456,7 @@ struct CheckFeatureParentChildRelationShip {
   static bool check(FeatureModel &FM) {
     return std::all_of(FM.begin(), FM.end(), [](Feature *F) {
       return llvm::isa<RootFeature>(F) ||
-             // Every parent of a Feature needs to have that as a child.
+             // Every parent of a Feature needs to have it as a child.
              std::any_of(F->getParent()->begin(), F->getParent()->end(),
                          [F](FeatureTreeNode *Child) { return F == Child; });
     });

--- a/include/vara/Feature/FeatureModelTransaction.h
+++ b/include/vara/Feature/FeatureModelTransaction.h
@@ -132,13 +132,19 @@ public:
   virtual void exec(FeatureModel &FM) = 0;
 
 protected:
-  /// \brief Set the parrent of a Feature.
+  /// \brief Set the parent of a \a Feature.
   static void setParent(Feature &F, Feature *Parent) { F.setParent(Parent); }
 
-  /// \brief Set the parrent of a \a Feature Child to F.
+  /// \brief Remove the parent of a \a Feature.
+  static void removeParent(Feature &F) { F.setParent(nullptr); }
+
+  /// \brief Add a \a Feature Child to F.
   static void addChild(Feature &F, Feature &Child) { F.addEdge(&Child); }
 
-  /// \brief Adds a new Feature to the FeatureModel.
+  /// \brief Remove \a Feature Child from F.
+  static void removeChild(Feature &F, Feature &Child) { F.removeEdge(&Child); }
+
+  /// \brief Adds a new \a Feature to the FeatureModel.
   ///
   /// \param FM model to add to
   /// \param NewFeature the Feature to add
@@ -147,6 +153,14 @@ protected:
   static Feature *addFeature(FeatureModel &FM,
                              std::unique_ptr<Feature> NewFeature) {
     return FM.addFeature(std::move(NewFeature));
+  }
+
+  /// \brief Remove \a Feature from a \a FeatureModel.
+  ///
+  /// \param FM model to remove from
+  /// \param F the Feature to delete
+  static void removeFeature(FeatureModel &FM, Feature &F) {
+    FM.removeFeature(F);
   }
 
   template <typename ModTy, typename... ArgTys>

--- a/include/vara/Feature/FeatureTreeNode.h
+++ b/include/vara/Feature/FeatureTreeNode.h
@@ -52,8 +52,6 @@ public:
 
   [[nodiscard]] FeatureTreeNode *getParent() const { return Parent; }
 
-  [[nodiscard]] bool isRoot() const { return Parent == nullptr; }
-
   [[nodiscard]] bool hasEdgeFrom(FeatureTreeNode &N) const {
     return Parent == &N;
   }
@@ -99,10 +97,13 @@ protected:
   }
 
 private:
-  void setParent(FeatureTreeNode &Feature) { Parent = &Feature; }
   void setParent(FeatureTreeNode *Feature) { Parent = Feature; }
 
   bool addEdge(FeatureTreeNode *Feature) { return DGNode::addEdge(*Feature); }
+
+  void removeEdge(FeatureTreeNode *Feature) {
+    return DGNode::removeEdge(*Feature);
+  }
 
   template <typename T>
   static void getChildrenImpl(FeatureTreeNode *N,

--- a/include/vara/Feature/OrderedFeatureVector.h
+++ b/include/vara/Feature/OrderedFeatureVector.h
@@ -21,7 +21,7 @@ public:
   OrderedFeatureVector() = default;
   OrderedFeatureVector(std::initializer_list<Feature *> Init) { insert(Init); }
   template <class FeatureIterTy>
-  OrderedFeatureVector(FeatureIterTy Begin, FeatureIterTy End) {
+  OrderedFeatureVector(FeatureIterTy &&Begin, FeatureIterTy &&End) {
     insert(std::forward<FeatureIterTy>(Begin),
            std::forward<FeatureIterTy>(End));
   }
@@ -48,7 +48,7 @@ public:
   }
 
   template <class FeatureIterTy>
-  void insert(FeatureIterTy Begin, FeatureIterTy End) {
+  void insert(FeatureIterTy &&Begin, FeatureIterTy &&End) {
     insert(llvm::make_range(std::forward<FeatureIterTy>(Begin),
                             std::forward<FeatureIterTy>(End)));
   }

--- a/include/vara/Feature/OrderedFeatureVector.h
+++ b/include/vara/Feature/OrderedFeatureVector.h
@@ -22,7 +22,8 @@ public:
   OrderedFeatureVector(std::initializer_list<Feature *> Init) { insert(Init); }
   template <class FeatureIterTy>
   OrderedFeatureVector(FeatureIterTy Begin, FeatureIterTy End) {
-    insert(std::forward<FeatureIterTy>(Begin), std::forward<FeatureIterTy>(End));
+    insert(std::forward<FeatureIterTy>(Begin),
+           std::forward<FeatureIterTy>(End));
   }
   OrderedFeatureVector(const OrderedFeatureVector &OFV) = delete;
   OrderedFeatureVector &operator=(const OrderedFeatureVector &) = delete;
@@ -33,6 +34,12 @@ public:
   /// Insert feature while preserving ordering.
   void insert(Feature *F);
 
+  /// Remove feature.
+  void remove(Feature *F) {
+    Features.erase(std::remove(Features.begin(), Features.end(), F),
+                   Features.end());
+  }
+
   template <class FeatureIterTy>
   void insert(llvm::iterator_range<FeatureIterTy> Iter) {
     for (const auto &F : Iter) {
@@ -42,7 +49,8 @@ public:
 
   template <class FeatureIterTy>
   void insert(FeatureIterTy Begin, FeatureIterTy End) {
-    insert(llvm::make_range(std::forward<FeatureIterTy>(Begin), std::forward<FeatureIterTy>(End)));
+    insert(llvm::make_range(std::forward<FeatureIterTy>(Begin),
+                            std::forward<FeatureIterTy>(End)));
   }
 
   void insert(std::initializer_list<Feature *> Init) {

--- a/lib/Feature/FeatureModel.cpp
+++ b/lib/Feature/FeatureModel.cpp
@@ -27,6 +27,9 @@ Feature *FeatureModel::addFeature(std::unique_ptr<Feature> NewFeature) {
 }
 
 void FeatureModel::removeFeature(Feature &F) {
+  if (&F == Root) {
+    Root = nullptr;
+  }
   OrderedFeatures.remove(&F);
   Features.erase(F.getName());
 }

--- a/lib/Feature/FeatureModel.cpp
+++ b/lib/Feature/FeatureModel.cpp
@@ -36,7 +36,7 @@ std::unique_ptr<FeatureModel> FeatureModel::clone() {
   FMB.setVmName(this->getName().str());
   FMB.setCommit(this->getCommit().str());
   FMB.setPath(this->getPath().string());
-  FMB.setRoot(this->getRoot()->getName().str());
+  FMB.setRootName(this->getRoot()->getName().str());
 
   for (const auto &KV : this->Features) {
     // TODO(s9latimm): Add unittests for cloned FeatureSourceRanges
@@ -47,6 +47,9 @@ std::unique_ptr<FeatureModel> FeatureModel::clone() {
     switch (KV.getValue()->getKind()) {
     case Feature::FeatureKind::FK_UNKNOWN:
       FMB.makeFeature<Feature>(KV.getValue()->getName().str());
+      break;
+    case Feature::FeatureKind::FK_ROOT:
+      FMB.makeFeature<RootFeature>(KV.getValue()->getName().str());
       break;
     case Feature::FeatureKind::FK_BINARY:
       if (auto *F = llvm::dyn_cast<BinaryFeature>(KV.getValue().get()); F) {
@@ -266,32 +269,28 @@ bool FeatureModelBuilder::buildTree(const string &FeatureName,
   return true;
 }
 
-FeatureModelBuilder *FeatureModelBuilder::setRoot(const std::string &RootName) {
-  assert(this->Root == nullptr && "Root already set.");
-
-  if (Features.find(RootName) == Features.end()) {
-    makeFeature<BinaryFeature>(RootName, false);
+bool FeatureModelBuilder::buildRoot() {
+  Root = Features.find(RootName) != Features.end()
+             ? Features[RootName].get()
+             : makeFeature<RootFeature>(RootName);
+  if (!llvm::isa_and_nonnull<RootFeature>(Root)) {
+    llvm::errs() << "error: Missing root node.\n";
+    return false;
   }
-  this->Root = Features[RootName].get();
 
   for (const auto &FeatureName : Features.keys()) {
-    if (FeatureName != RootName && Parents.find(FeatureName) == Parents.end()) {
+    if (FeatureName != Root->getName() &&
+        Parents.find(FeatureName) == Parents.end()) {
       Children[RootName].insert(std::string(FeatureName));
       Parents[FeatureName] = RootName;
     }
   }
-  return this;
+  return true;
 }
 
 std::unique_ptr<FeatureModel> FeatureModelBuilder::buildFeatureModel() {
-  if (!Root) {
-    setRoot();
-  }
-  assert(Root && "Root not set.");
   std::set<std::string> Visited;
-
-  if (!buildConstraints() ||
-      !buildTree(std::string(Root->getName()), Visited)) {
+  if (!buildRoot() || !buildConstraints() || !buildTree(RootName, Visited)) {
     return nullptr;
   }
   return std::make_unique<FeatureModel>(Name, Path, Commit, std::move(Features),

--- a/lib/Feature/FeatureModel.cpp
+++ b/lib/Feature/FeatureModel.cpp
@@ -26,6 +26,11 @@ Feature *FeatureModel::addFeature(std::unique_ptr<Feature> NewFeature) {
   return InsertedFeature;
 }
 
+void FeatureModel::removeFeature(Feature &F) {
+  OrderedFeatures.remove(&F);
+  Features.erase(F.getName());
+}
+
 std::unique_ptr<FeatureModel> FeatureModel::clone() {
   FeatureModelBuilder FMB;
   FMB.setVmName(this->getName().str());

--- a/lib/Feature/FeatureModelParser.cpp
+++ b/lib/Feature/FeatureModelParser.cpp
@@ -97,6 +97,9 @@ bool FeatureModelXmlParser::parseConfigurationOption(xmlNode *Node,
       }
     }
   }
+  if (Name == "root") {
+    return FMB.makeFeature<RootFeature>(Name);
+  }
   if (Num) {
     if (Values.empty()) {
       return FMB.makeFeature<NumericFeature>(Name,

--- a/lib/Feature/FeatureModelWriter.cpp
+++ b/lib/Feature/FeatureModelWriter.cpp
@@ -209,7 +209,7 @@ int FeatureModelXmlWriter::writeFeature(xmlTextWriterPtr Writer,
   CHECK_RC
 
   // parent
-  if (!Feature1.isRoot()) {
+  if (Feature1.getParentFeature()) {
     RC = xmlTextWriterWriteElement(
         Writer, XmlConstants::PARENT,
         charToUChar(Feature1.getParentFeature()->getName().data()));
@@ -270,7 +270,7 @@ int FeatureModelXmlWriter::writeFeature(xmlTextWriterPtr Writer,
   // excludes
   OrderedFeatureVector Excludes;
 
-  if (!Feature1.isRoot() && llvm::isa<Relationship>(Feature1.getParent())) {
+  if (llvm::isa_and_nonnull<Relationship>(Feature1.getParent())) {
     auto ES = Feature1.getParent()->getChildren<Feature>();
     ES.erase(&Feature1);
     Excludes.insert(ES.begin(), ES.end());

--- a/lib/Feature/FeatureModelWriter.cpp
+++ b/lib/Feature/FeatureModelWriter.cpp
@@ -120,7 +120,7 @@ int FeatureModelXmlWriter::writeBinaryFeatures(xmlTextWriterPtr Writer) {
   CHECK_RC
 
   for (Feature *F : Fm.features()) {
-    if (llvm::isa<BinaryFeature>(F)) {
+    if (llvm::isa<RootFeature>(F) || llvm::isa<BinaryFeature>(F)) {
       RC = writeFeature(Writer, *F);
       CHECK_RC
     }

--- a/unittests/Feature/BinaryFeature.cpp
+++ b/unittests/Feature/BinaryFeature.cpp
@@ -11,7 +11,7 @@ TEST(BinaryFeature, basicAccessors) {
 
   EXPECT_EQ("A", A.getName());
   EXPECT_TRUE(A.isOptional());
-  EXPECT_TRUE(A.isRoot());
+  EXPECT_FALSE(A.getParent());
 }
 
 TEST(BinaryFeature, isa) {
@@ -29,7 +29,7 @@ TEST(BinaryFeature, BinaryFeatureRoot) {
 
   auto FM = B.buildFeatureModel();
 
-  EXPECT_TRUE(FM->getFeature("F")->isRoot());
+  EXPECT_FALSE(FM->getFeature("F")->getParent());
   EXPECT_EQ(FM->getFeature("F"), FM->getRoot());
 }
 

--- a/unittests/Feature/BinaryFeature.cpp
+++ b/unittests/Feature/BinaryFeature.cpp
@@ -42,7 +42,7 @@ TEST(BinaryFeature, BinaryFeatureChildren) {
   EXPECT_EQ(
       std::distance(FM->getFeature("a")->begin(), FM->getFeature("a")->end()),
       1);
-  if (auto *F = llvm::dyn_cast<Feature>(*FM->getFeature("a")->begin()); F) {
+  if (auto *F = llvm::dyn_cast<Feature>(*FM->getFeature("a")->begin())) {
     EXPECT_EQ("aa", F->getName());
   } else {
     FAIL();

--- a/unittests/Feature/CMakeLists.txt
+++ b/unittests/Feature/CMakeLists.txt
@@ -10,4 +10,5 @@ add_vara_unittest(VaRAFeatureTests
   NumericFeature.cpp
   OrderedFeatureVector.cpp
   Relationship.cpp
+  RootFeature.cpp
   )

--- a/unittests/Feature/FeatureModel.cpp
+++ b/unittests/Feature/FeatureModel.cpp
@@ -45,8 +45,7 @@ TEST(FeatureModel, cloneRoot) {
 
   // The inner EXPECT_TRUE just handles the nodiscard of getParent
   // NOLINTNEXTLINE
-  ASSERT_EXIT(EXPECT_TRUE(FM->getFeature("a")->getParent()),
-              testing::KilledBySignal(SIGSEGV), ".*");
+  EXPECT_DEATH(EXPECT_TRUE(FM->getFeature("a")->getParent()), ".*");
   EXPECT_FALSE(Clone->getFeature("a")->getParent());
 }
 
@@ -82,8 +81,7 @@ TEST(FeatureModel, cloneConstraint) {
 
   // The inner EXPECT_TRUE just handles the nodiscard of clone
   // NOLINTNEXTLINE
-  ASSERT_EXIT(EXPECT_TRUE(Deleted->clone()), testing::KilledBySignal(SIGSEGV),
-              ".*");
+  EXPECT_DEATH(EXPECT_TRUE(Deleted->clone()), ".*");
   EXPECT_TRUE((*Clone->getFeature("a")->constraints().begin())->clone());
 }
 

--- a/unittests/Feature/FeatureModel.cpp
+++ b/unittests/Feature/FeatureModel.cpp
@@ -45,8 +45,8 @@ TEST(FeatureModel, cloneRoot) {
 
   // The inner EXPECT_TRUE just handles the nodiscard of getParent
   // NOLINTNEXTLINE
-  EXPECT_DEATH(EXPECT_TRUE(FM->getFeature("a")->getParent()), ".*");
-  EXPECT_FALSE(Clone->getFeature("a")->getParent());
+  EXPECT_DEATH(EXPECT_TRUE(llvm::isa<RootFeature>(FM->getFeature("a"))), ".*");
+  EXPECT_TRUE(llvm::isa<RootFeature>(Clone->getFeature("a")));
 }
 
 TEST(FeatureModel, cloneRelationship) {

--- a/unittests/Feature/FeatureModel.cpp
+++ b/unittests/Feature/FeatureModel.cpp
@@ -278,31 +278,26 @@ TEST_F(FeatureModelConsistencyCheckerTest,
           *FM));
 }
 
-// TEST_F(FeatureModelConsistencyCheckerTest, EveryFMNeedsOneRootButNonPresent)
-// {
-//  FeatureModelBuilder B;
-//  auto FM = B.buildFeatureModel();
-//
-//  FeatureModelModification::removeFeature(*FM, *FM->getRoot());
-//
-//  EXPECT_FALSE(
-//      FeatureModelConsistencyChecker<ExactlyOneRootNode>::isFeatureModelValid(
-//          *FM));
-//}
+TEST_F(FeatureModelConsistencyCheckerTest, EveryFMNeedsOneRootButNonPresent) {
+  FeatureModelBuilder B;
+  auto FM = B.buildFeatureModel();
 
-// TEST_F(FeatureModelConsistencyCheckerTest,
-//       EveryFMNeedsOneRootButMultiplePresent) {
-//  FeatureModelBuilder B;
-//  B.makeFeature<BinaryFeature>("root");
-//  auto FM = B.buildFeatureModel();
-//
-//  FeatureModelModification::addFeature(*FM,
-//                                       std::make_unique<BinaryFeature>("b"));
-//  FeatureModelModification::removeParent(*FM->getFeature("b"));
-//
-//  EXPECT_FALSE(
-//      FeatureModelConsistencyChecker<ExactlyOneRootNode>::isFeatureModelValid(
-//          *FM));
-//}
+  FeatureModelModification::removeFeature(*FM, *FM->getRoot());
+
+  EXPECT_FALSE(
+      FeatureModelConsistencyChecker<ExactlyOneRootNode>::isFeatureModelValid(
+          *FM));
+}
+
+TEST_F(FeatureModelConsistencyCheckerTest,
+       EveryFMNeedsOneRootButMultiplePresent) {
+  auto FM = FeatureModelBuilder().buildFeatureModel();
+
+  FeatureModelModification::addFeature(*FM, std::make_unique<RootFeature>("b"));
+
+  EXPECT_FALSE(
+      FeatureModelConsistencyChecker<ExactlyOneRootNode>::isFeatureModelValid(
+          *FM));
+}
 
 } // namespace vara::feature

--- a/unittests/Feature/FeatureModel.cpp
+++ b/unittests/Feature/FeatureModel.cpp
@@ -34,8 +34,8 @@ TEST(FeatureModel, cloneUnique) {
 
 TEST(FeatureModel, cloneRoot) {
   FeatureModelBuilder B;
-  B.makeFeature<BinaryFeature>("a");
-  B.setRoot("a");
+  B.makeFeature<RootFeature>("a");
+  B.setRootName("a");
   auto FM = B.buildFeatureModel();
   assert(FM);
 
@@ -278,30 +278,31 @@ TEST_F(FeatureModelConsistencyCheckerTest,
           *FM));
 }
 
-TEST_F(FeatureModelConsistencyCheckerTest, EveryFMNeedsOneRootButNonPresent) {
-  FeatureModelBuilder B;
-  auto FM = B.buildFeatureModel();
+// TEST_F(FeatureModelConsistencyCheckerTest, EveryFMNeedsOneRootButNonPresent)
+// {
+//  FeatureModelBuilder B;
+//  auto FM = B.buildFeatureModel();
+//
+//  FeatureModelModification::removeFeature(*FM, *FM->getRoot());
+//
+//  EXPECT_FALSE(
+//      FeatureModelConsistencyChecker<ExactlyOneRootNode>::isFeatureModelValid(
+//          *FM));
+//}
 
-  FeatureModelModification::removeFeature(*FM, *FM->getRoot());
-
-  EXPECT_FALSE(
-      FeatureModelConsistencyChecker<ExactlyOneRootNode>::isFeatureModelValid(
-          *FM));
-}
-
-TEST_F(FeatureModelConsistencyCheckerTest,
-       EveryFMNeedsOneRootButMultiplePresent) {
-  FeatureModelBuilder B;
-  B.makeFeature<BinaryFeature>("root");
-  auto FM = B.buildFeatureModel();
-
-  FeatureModelModification::addFeature(*FM,
-                                       std::make_unique<BinaryFeature>("b"));
-  FeatureModelModification::removeParent(*FM->getFeature("b"));
-
-  EXPECT_FALSE(
-      FeatureModelConsistencyChecker<ExactlyOneRootNode>::isFeatureModelValid(
-          *FM));
-}
+// TEST_F(FeatureModelConsistencyCheckerTest,
+//       EveryFMNeedsOneRootButMultiplePresent) {
+//  FeatureModelBuilder B;
+//  B.makeFeature<BinaryFeature>("root");
+//  auto FM = B.buildFeatureModel();
+//
+//  FeatureModelModification::addFeature(*FM,
+//                                       std::make_unique<BinaryFeature>("b"));
+//  FeatureModelModification::removeParent(*FM->getFeature("b"));
+//
+//  EXPECT_FALSE(
+//      FeatureModelConsistencyChecker<ExactlyOneRootNode>::isFeatureModelValid(
+//          *FM));
+//}
 
 } // namespace vara::feature

--- a/unittests/Feature/FeatureModelTransaction.cpp
+++ b/unittests/Feature/FeatureModelTransaction.cpp
@@ -20,8 +20,8 @@ protected:
     FM = B.buildFeatureModel();
   }
 
-  // Dummy method to fullfill the FeatureModelModification interface
-  void exec(FeatureModel &FM) override{};
+  // Dummy method to fulfill the FeatureModelModification interface
+  void exec(FeatureModel &_) override{};
 
   std::unique_ptr<FeatureModel> FM;
 };

--- a/unittests/Feature/FeatureModelTransaction.cpp
+++ b/unittests/Feature/FeatureModelTransaction.cpp
@@ -38,7 +38,7 @@ TEST_F(FeatureModelModificationTest, addFeatureToModel_simpleAdd) {
 
   EXPECT_EQ(FMSizeBefore + 1, FM->size());
   EXPECT_TRUE(FM->getFeature("a"));
-  EXPECT_FALSE(FM->getFeature("a")->getParentFeature()->getParent());
+  EXPECT_TRUE(llvm::isa<RootFeature>(FM->getFeature("a")->getParentFeature()));
   EXPECT_TRUE(FM->getFeature("aa"));
   EXPECT_EQ(FM->getFeature("a"), FM->getFeature("aa")->getParentFeature());
 }
@@ -96,7 +96,7 @@ TEST_F(FeatureModelTransactionCopyTest, createAndDestroyWithoutChange) {
   FT.commit();
   EXPECT_EQ(FMSizeBefore, FM->size());
   EXPECT_NE(nullptr, FM->getFeature("a"));
-  EXPECT_FALSE(FM->getFeature("a")->getParentFeature()->getParent());
+  EXPECT_TRUE(llvm::isa<RootFeature>(FM->getFeature("a")->getParentFeature()));
 }
 
 TEST_F(FeatureModelTransactionCopyTest, addFeatureToModel) {
@@ -107,7 +107,7 @@ TEST_F(FeatureModelTransactionCopyTest, addFeatureToModel) {
 
   EXPECT_EQ(FMSizeBefore, FM->size());
   EXPECT_TRUE(FM->getFeature("a"));
-  EXPECT_FALSE(FM->getFeature("a")->getParentFeature()->getParent());
+  EXPECT_TRUE(llvm::isa<RootFeature>(FM->getFeature("a")->getParentFeature()));
   EXPECT_FALSE(FM->getFeature("ab")); // Change should not be visible
 
   auto NewFM = FT.commit(); // Commit changes
@@ -116,12 +116,13 @@ TEST_F(FeatureModelTransactionCopyTest, addFeatureToModel) {
   EXPECT_FALSE(FM->getFeature("ab"));
   EXPECT_EQ(FMSizeBefore, FM->size());
   EXPECT_TRUE(FM->getFeature("a"));
-  EXPECT_FALSE(FM->getFeature("a")->getParentFeature()->getParent());
+  EXPECT_TRUE(llvm::isa<RootFeature>(FM->getFeature("a")->getParentFeature()));
 
   // Changes should be visible on the new model
   EXPECT_EQ(NewFM->size(), FM->size() + 1);
   EXPECT_TRUE(NewFM->getFeature("a"));
-  EXPECT_FALSE(NewFM->getFeature("a")->getParentFeature()->getParent());
+  EXPECT_TRUE(
+      llvm::isa<RootFeature>(NewFM->getFeature("a")->getParentFeature()));
   EXPECT_TRUE(NewFM->getFeature("ab")); // Change should be visible
   EXPECT_EQ(NewFM->getFeature("a"),
             NewFM->getFeature("ab")->getParentFeature());
@@ -135,7 +136,7 @@ TEST_F(FeatureModelTransactionCopyTest, addFeatureToModelThenAboard) {
 
   EXPECT_EQ(FMSizeBefore, FM->size());
   EXPECT_TRUE(FM->getFeature("a"));
-  EXPECT_FALSE(FM->getFeature("a")->getParentFeature()->getParent());
+  EXPECT_TRUE(llvm::isa<RootFeature>(FM->getFeature("a")->getParentFeature()));
   EXPECT_FALSE(FM->getFeature("ab")); // Change should not be visible
 
   FT.abort();
@@ -147,7 +148,7 @@ TEST_F(FeatureModelTransactionCopyTest, addFeatureToModelThenAboard) {
 
   EXPECT_EQ(FMSizeBefore, FM->size());
   EXPECT_TRUE(FM->getFeature("a"));
-  EXPECT_FALSE(FM->getFeature("a")->getParentFeature()->getParent());
+  EXPECT_TRUE(llvm::isa<RootFeature>(FM->getFeature("a")->getParentFeature()));
   EXPECT_FALSE(FM->getFeature("ab")); // Change should not be visible
 }
 
@@ -178,7 +179,8 @@ TEST_F(FeatureModelTransactionModifyTest, createAndDestroyWithoutChange) {
   EXPECT_EQ(FMSizeBefore, FM->size());
   EXPECT_EQ(FMSizeBefore, UpdatedFM->size());
   EXPECT_NE(nullptr, UpdatedFM->getFeature("a"));
-  EXPECT_FALSE(UpdatedFM->getFeature("a")->getParentFeature()->getParent());
+  EXPECT_TRUE(
+      llvm::isa<RootFeature>(UpdatedFM->getFeature("a")->getParentFeature()));
 }
 
 TEST_F(FeatureModelTransactionModifyTest, addFeatureToModel) {
@@ -189,14 +191,14 @@ TEST_F(FeatureModelTransactionModifyTest, addFeatureToModel) {
 
   EXPECT_EQ(FMSizeBefore, FM->size());
   EXPECT_TRUE(FM->getFeature("a"));
-  EXPECT_FALSE(FM->getFeature("a")->getParentFeature()->getParent());
+  EXPECT_TRUE(llvm::isa<RootFeature>(FM->getFeature("a")->getParentFeature()));
   EXPECT_FALSE(FM->getFeature("ab")); // Change should not be visible
 
   FT.commit(); // Commit changes
 
   EXPECT_EQ(FMSizeBefore + 1, FM->size());
   EXPECT_TRUE(FM->getFeature("a"));
-  EXPECT_FALSE(FM->getFeature("a")->getParentFeature()->getParent());
+  EXPECT_TRUE(llvm::isa<RootFeature>(FM->getFeature("a")->getParentFeature()));
   EXPECT_TRUE(FM->getFeature("ab")); // Change should be visible
   EXPECT_EQ(FM->getFeature("a"), FM->getFeature("ab")->getParentFeature());
 }
@@ -209,7 +211,7 @@ TEST_F(FeatureModelTransactionModifyTest, addFeatureToModelThenAboard) {
 
   EXPECT_EQ(FMSizeBefore, FM->size());
   EXPECT_TRUE(FM->getFeature("a"));
-  EXPECT_FALSE(FM->getFeature("a")->getParentFeature()->getParent());
+  EXPECT_TRUE(llvm::isa<RootFeature>(FM->getFeature("a")->getParentFeature()));
   EXPECT_FALSE(FM->getFeature("ab")); // Change should not be visible
 
   FT.abort();
@@ -218,7 +220,7 @@ TEST_F(FeatureModelTransactionModifyTest, addFeatureToModelThenAboard) {
 
   EXPECT_EQ(FMSizeBefore, FM->size());
   EXPECT_TRUE(FM->getFeature("a"));
-  EXPECT_FALSE(FM->getFeature("a")->getParentFeature()->getParent());
+  EXPECT_TRUE(llvm::isa<RootFeature>(FM->getFeature("a")->getParentFeature()));
   EXPECT_FALSE(FM->getFeature("ab")); // Change should not be visible
 }
 

--- a/unittests/Feature/FeatureModelTransaction.cpp
+++ b/unittests/Feature/FeatureModelTransaction.cpp
@@ -38,7 +38,7 @@ TEST_F(FeatureModelModificationTest, addFeatureToModel_simpleAdd) {
 
   EXPECT_EQ(FMSizeBefore + 1, FM->size());
   EXPECT_TRUE(FM->getFeature("a"));
-  EXPECT_TRUE(FM->getFeature("a")->getParentFeature()->isRoot());
+  EXPECT_FALSE(FM->getFeature("a")->getParentFeature()->getParent());
   EXPECT_TRUE(FM->getFeature("aa"));
   EXPECT_EQ(FM->getFeature("a"), FM->getFeature("aa")->getParentFeature());
 }
@@ -96,7 +96,7 @@ TEST_F(FeatureModelTransactionCopyTest, createAndDestroyWithoutChange) {
   FT.commit();
   EXPECT_EQ(FMSizeBefore, FM->size());
   EXPECT_NE(nullptr, FM->getFeature("a"));
-  EXPECT_TRUE(FM->getFeature("a")->getParentFeature()->isRoot());
+  EXPECT_FALSE(FM->getFeature("a")->getParentFeature()->getParent());
 }
 
 TEST_F(FeatureModelTransactionCopyTest, addFeatureToModel) {
@@ -107,7 +107,7 @@ TEST_F(FeatureModelTransactionCopyTest, addFeatureToModel) {
 
   EXPECT_EQ(FMSizeBefore, FM->size());
   EXPECT_TRUE(FM->getFeature("a"));
-  EXPECT_TRUE(FM->getFeature("a")->getParentFeature()->isRoot());
+  EXPECT_FALSE(FM->getFeature("a")->getParentFeature()->getParent());
   EXPECT_FALSE(FM->getFeature("ab")); // Change should not be visible
 
   auto NewFM = FT.commit(); // Commit changes
@@ -116,12 +116,12 @@ TEST_F(FeatureModelTransactionCopyTest, addFeatureToModel) {
   EXPECT_FALSE(FM->getFeature("ab"));
   EXPECT_EQ(FMSizeBefore, FM->size());
   EXPECT_TRUE(FM->getFeature("a"));
-  EXPECT_TRUE(FM->getFeature("a")->getParentFeature()->isRoot());
+  EXPECT_FALSE(FM->getFeature("a")->getParentFeature()->getParent());
 
   // Changes should be visible on the new model
   EXPECT_EQ(NewFM->size(), FM->size() + 1);
   EXPECT_TRUE(NewFM->getFeature("a"));
-  EXPECT_TRUE(NewFM->getFeature("a")->getParentFeature()->isRoot());
+  EXPECT_FALSE(NewFM->getFeature("a")->getParentFeature()->getParent());
   EXPECT_TRUE(NewFM->getFeature("ab")); // Change should be visible
   EXPECT_EQ(NewFM->getFeature("a"),
             NewFM->getFeature("ab")->getParentFeature());
@@ -135,7 +135,7 @@ TEST_F(FeatureModelTransactionCopyTest, addFeatureToModelThenAboard) {
 
   EXPECT_EQ(FMSizeBefore, FM->size());
   EXPECT_TRUE(FM->getFeature("a"));
-  EXPECT_TRUE(FM->getFeature("a")->getParentFeature()->isRoot());
+  EXPECT_FALSE(FM->getFeature("a")->getParentFeature()->getParent());
   EXPECT_FALSE(FM->getFeature("ab")); // Change should not be visible
 
   FT.abort();
@@ -147,7 +147,7 @@ TEST_F(FeatureModelTransactionCopyTest, addFeatureToModelThenAboard) {
 
   EXPECT_EQ(FMSizeBefore, FM->size());
   EXPECT_TRUE(FM->getFeature("a"));
-  EXPECT_TRUE(FM->getFeature("a")->getParentFeature()->isRoot());
+  EXPECT_FALSE(FM->getFeature("a")->getParentFeature()->getParent());
   EXPECT_FALSE(FM->getFeature("ab")); // Change should not be visible
 }
 
@@ -178,7 +178,7 @@ TEST_F(FeatureModelTransactionModifyTest, createAndDestroyWithoutChange) {
   EXPECT_EQ(FMSizeBefore, FM->size());
   EXPECT_EQ(FMSizeBefore, UpdatedFM->size());
   EXPECT_NE(nullptr, UpdatedFM->getFeature("a"));
-  EXPECT_TRUE(UpdatedFM->getFeature("a")->getParentFeature()->isRoot());
+  EXPECT_FALSE(UpdatedFM->getFeature("a")->getParentFeature()->getParent());
 }
 
 TEST_F(FeatureModelTransactionModifyTest, addFeatureToModel) {
@@ -189,14 +189,14 @@ TEST_F(FeatureModelTransactionModifyTest, addFeatureToModel) {
 
   EXPECT_EQ(FMSizeBefore, FM->size());
   EXPECT_TRUE(FM->getFeature("a"));
-  EXPECT_TRUE(FM->getFeature("a")->getParentFeature()->isRoot());
+  EXPECT_FALSE(FM->getFeature("a")->getParentFeature()->getParent());
   EXPECT_FALSE(FM->getFeature("ab")); // Change should not be visible
 
   FT.commit(); // Commit changes
 
   EXPECT_EQ(FMSizeBefore + 1, FM->size());
   EXPECT_TRUE(FM->getFeature("a"));
-  EXPECT_TRUE(FM->getFeature("a")->getParentFeature()->isRoot());
+  EXPECT_FALSE(FM->getFeature("a")->getParentFeature()->getParent());
   EXPECT_TRUE(FM->getFeature("ab")); // Change should be visible
   EXPECT_EQ(FM->getFeature("a"), FM->getFeature("ab")->getParentFeature());
 }
@@ -209,7 +209,7 @@ TEST_F(FeatureModelTransactionModifyTest, addFeatureToModelThenAboard) {
 
   EXPECT_EQ(FMSizeBefore, FM->size());
   EXPECT_TRUE(FM->getFeature("a"));
-  EXPECT_TRUE(FM->getFeature("a")->getParentFeature()->isRoot());
+  EXPECT_FALSE(FM->getFeature("a")->getParentFeature()->getParent());
   EXPECT_FALSE(FM->getFeature("ab")); // Change should not be visible
 
   FT.abort();
@@ -218,7 +218,7 @@ TEST_F(FeatureModelTransactionModifyTest, addFeatureToModelThenAboard) {
 
   EXPECT_EQ(FMSizeBefore, FM->size());
   EXPECT_TRUE(FM->getFeature("a"));
-  EXPECT_TRUE(FM->getFeature("a")->getParentFeature()->isRoot());
+  EXPECT_FALSE(FM->getFeature("a")->getParentFeature()->getParent());
   EXPECT_FALSE(FM->getFeature("ab")); // Change should not be visible
 }
 

--- a/unittests/Feature/NumericFeature.cpp
+++ b/unittests/Feature/NumericFeature.cpp
@@ -12,7 +12,7 @@ TEST(NumericFeature, NumericFeatureBasics) {
 
   EXPECT_EQ("A", A.getName());
   EXPECT_TRUE(A.isOptional());
-  EXPECT_TRUE(A.isRoot());
+  EXPECT_FALSE(A.getParent());
 }
 
 TEST(NumericFeature, isa) {
@@ -46,7 +46,7 @@ TEST(NumericFeature, NumericFeatureRoot) {
 
   auto FM = B.buildFeatureModel();
 
-  EXPECT_TRUE(FM->getFeature("F")->isRoot());
+  EXPECT_FALSE(FM->getFeature("F")->getParent());
   EXPECT_EQ(FM->getFeature("F"), FM->getRoot());
 }
 

--- a/unittests/Feature/NumericFeature.cpp
+++ b/unittests/Feature/NumericFeature.cpp
@@ -58,7 +58,7 @@ TEST(NumericFeature, NumericFeatureChildren) {
   EXPECT_EQ(
       std::distance(FM->getFeature("a")->begin(), FM->getFeature("a")->end()),
       1);
-  if (auto *F = llvm::dyn_cast<Feature>(*FM->getFeature("a")->begin()); F) {
+  if (auto *F = llvm::dyn_cast<Feature>(*FM->getFeature("a")->begin())) {
     EXPECT_EQ("aa", F->getName());
   } else {
     FAIL();

--- a/unittests/Feature/NumericFeature.cpp
+++ b/unittests/Feature/NumericFeature.cpp
@@ -20,6 +20,7 @@ TEST(NumericFeature, isa) {
 
   EXPECT_TRUE(llvm::isa<NumericFeature>(A));
   EXPECT_FALSE(llvm::isa<BinaryFeature>(A));
+  EXPECT_FALSE(llvm::isa<RootFeature>(A));
 }
 
 TEST(NumericFeature, NumericFeaturePair) {
@@ -42,12 +43,9 @@ TEST(NumericFeature, NumericFeatureRoot) {
   auto B = FeatureModelBuilder();
 
   B.makeFeature<NumericFeature>("F", std::pair<int, int>(0, 1));
-  B.setRoot("F");
+  B.setRootName("F");
 
-  auto FM = B.buildFeatureModel();
-
-  EXPECT_FALSE(FM->getFeature("F")->getParent());
-  EXPECT_EQ(FM->getFeature("F"), FM->getRoot());
+  EXPECT_FALSE(B.buildFeatureModel());
 }
 
 TEST(NumericFeature, NumericFeatureChildren) {
@@ -60,9 +58,7 @@ TEST(NumericFeature, NumericFeatureChildren) {
   EXPECT_EQ(
       std::distance(FM->getFeature("a")->begin(), FM->getFeature("a")->end()),
       1);
-  if (auto *F =
-          llvm::dyn_cast<vara::feature::Feature>(*FM->getFeature("a")->begin());
-      F) {
+  if (auto *F = llvm::dyn_cast<Feature>(*FM->getFeature("a")->begin()); F) {
     EXPECT_EQ("aa", F->getName());
   } else {
     FAIL();

--- a/unittests/Feature/RootFeature.cpp
+++ b/unittests/Feature/RootFeature.cpp
@@ -44,11 +44,9 @@ TEST(RootFeature, RootFeatureChildren) {
   EXPECT_EQ(
       std::distance(FM->getFeature("a")->begin(), FM->getFeature("a")->end()),
       1);
-  if (auto *F = llvm::dyn_cast<Feature>(*FM->getFeature("a")->begin()); F) {
-    EXPECT_EQ("aa", F->getName());
-  } else {
-    FAIL();
-  }
+  Feature *FirstChild = llvm::dyn_cast<Feature>(*FM->getFeature("a")->begin());
+  EXPECT_NE(FirstChild, nullptr);
+  EXPECT_EQ("aa", F->getName());
 }
 
 } // namespace vara::feature

--- a/unittests/Feature/RootFeature.cpp
+++ b/unittests/Feature/RootFeature.cpp
@@ -6,34 +6,36 @@
 #include "gtest/gtest.h"
 
 namespace vara::feature {
-TEST(BinaryFeature, basicAccessors) {
-  BinaryFeature A("A", true);
+TEST(RootFeature, basicAccessors) {
+  RootFeature A("A");
 
   EXPECT_EQ("A", A.getName());
-  EXPECT_TRUE(A.isOptional());
+  EXPECT_FALSE(A.isOptional());
   EXPECT_FALSE(A.getParent());
 }
 
-TEST(BinaryFeature, isa) {
-  BinaryFeature A("A", true);
+TEST(RootFeature, isa) {
+  RootFeature A("A");
 
-  EXPECT_TRUE(llvm::isa<BinaryFeature>(A));
+  EXPECT_TRUE(llvm::isa<RootFeature>(A));
+  EXPECT_FALSE(llvm::isa<BinaryFeature>(A));
   EXPECT_FALSE(llvm::isa<NumericFeature>(A));
-  EXPECT_FALSE(llvm::isa<RootFeature>(A));
 }
 
-TEST(BinaryFeature, BinaryFeatureRoot) {
+TEST(RootFeature, RootFeatureRoot) {
   auto B = FeatureModelBuilder();
 
-  B.makeFeature<BinaryFeature>("F");
+  B.makeFeature<RootFeature>("F");
   B.setRootName("F");
+  auto FM = B.buildFeatureModel();
 
-  EXPECT_FALSE(B.buildFeatureModel());
+  EXPECT_TRUE(FM);
+  EXPECT_EQ("F", FM->getRoot()->getName());
 }
 
-TEST(BinaryFeature, BinaryFeatureChildren) {
+TEST(RootFeature, RootFeatureChildren) {
   FeatureModelBuilder B;
-  B.makeFeature<BinaryFeature>("a");
+  B.setRootName("a")->makeFeature<RootFeature>("a");
   B.addEdge("a", "aa")->makeFeature<BinaryFeature>("aa");
 
   auto FM = B.buildFeatureModel();

--- a/unittests/Feature/RootFeature.cpp
+++ b/unittests/Feature/RootFeature.cpp
@@ -44,9 +44,9 @@ TEST(RootFeature, RootFeatureChildren) {
   EXPECT_EQ(
       std::distance(FM->getFeature("a")->begin(), FM->getFeature("a")->end()),
       1);
-  Feature *FirstChild = llvm::dyn_cast<Feature>(*FM->getFeature("a")->begin());
+  auto *FirstChild = llvm::dyn_cast<Feature>(*FM->getFeature("a")->begin());
   EXPECT_NE(FirstChild, nullptr);
-  EXPECT_EQ("aa", F->getName());
+  EXPECT_EQ("aa", FirstChild->getName());
 }
 
 } // namespace vara::feature

--- a/unittests/Feature/RootFeature.cpp
+++ b/unittests/Feature/RootFeature.cpp
@@ -44,9 +44,11 @@ TEST(RootFeature, RootFeatureChildren) {
   EXPECT_EQ(
       std::distance(FM->getFeature("a")->begin(), FM->getFeature("a")->end()),
       1);
-  auto *FirstChild = llvm::dyn_cast<Feature>(*FM->getFeature("a")->begin());
-  EXPECT_NE(FirstChild, nullptr);
-  EXPECT_EQ("aa", FirstChild->getName());
+  if (auto *F = llvm::dyn_cast<Feature>(*FM->getFeature("a")->begin())) {
+    EXPECT_EQ("aa", F->getName());
+  } else {
+    FAIL();
+  }
 }
 
 } // namespace vara::feature


### PR DESCRIPTION
Add modifications to test broken FMs, refactor root nodes and clean up public interface.

- [x] Add removal of edges, children and features as modifications
  - [x] Enable creation of broken FM through inheritance
- [x] Remove `Feature::isRoot` to prevent misconception
  - [x] Add `RootFeature` class
  - [x] Refactor builder
  - [x] Refactor comparisons to root with `llvm::isa`
- [x] Clean up unused / deprecated constructors
- [x] Update python bindings
  - [x] Add `RootFeature`
  - [x] Add `feature_model.get_feature`
  - [x] Clean up modifications / deprecated methods
- [x] add `venv/` to gitignore 