### PR TITLE
Refactor builder with transactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/
 .*.*.swp
 .clangd/
 __pycache__/
+*.pyc
 compile_commands.json
 vara_feature.egg-info
 dist/

--- a/bindings/python/vara-feature/pybind_FeatureModel.cpp
+++ b/bindings/python/vara-feature/pybind_FeatureModel.cpp
@@ -1,7 +1,7 @@
 #include "pybind11/attr.h"
 #include "pybind_common.h"
-#include "vara/Feature/Feature.h"
 #include "vara/Feature/FeatureModel.h"
+#include "vara/Feature/FeatureModelTransaction.h"
 
 #include "pybind11/detail/common.h"
 #include "pybind11/pybind11.h"
@@ -22,7 +22,9 @@ void init_feature_model_module(py::module &M) {
       .def_property(
           "commit",
           [](const vf::FeatureModel &FM) { return FM.getCommit().str(); },
-          &vf::FeatureModel::setCommit,
+          [](vf::FeatureModel &FM, std::string Commit) {
+            vf::setCommit(FM, std::move(Commit));
+          },
           R"pbdoc(Returns the commit associated to the FeatureModel.)pbdoc")
       .def("get_root", &vf::FeatureModel::getRoot,
            py::return_value_policy::reference,

--- a/include/vara/Feature/Constraint.h
+++ b/include/vara/Feature/Constraint.h
@@ -572,6 +572,10 @@ private:
 
 class Feature;
 
+namespace detail {
+class FeatureModelModification;
+} // namespace detail
+
 class PrimaryFeatureConstraint : public PrimaryConstraint {
 public:
   PrimaryFeatureConstraint(std::variant<Feature *, std::unique_ptr<Feature>> FV)
@@ -595,7 +599,7 @@ public:
   void accept(ConstraintVisitor &V) override;
 
 private:
-  friend FeatureModelBuilder;
+  friend detail::FeatureModelModification;
 
   std::variant<Feature *, std::unique_ptr<Feature>> FV;
 

--- a/include/vara/Feature/Constraint.h
+++ b/include/vara/Feature/Constraint.h
@@ -577,6 +577,8 @@ class FeatureModelModification;
 } // namespace detail
 
 class PrimaryFeatureConstraint : public PrimaryConstraint {
+  friend detail::FeatureModelModification;
+
 public:
   PrimaryFeatureConstraint(std::variant<Feature *, std::unique_ptr<Feature>> FV)
       : PrimaryConstraint(ConstraintKind::CK_FEATURE), FV(std::move(FV)) {}
@@ -599,8 +601,6 @@ public:
   void accept(ConstraintVisitor &V) override;
 
 private:
-  friend detail::FeatureModelModification;
-
   std::variant<Feature *, std::unique_ptr<Feature>> FV;
 
   void setFeature(Feature *F) { this->FV = F; }

--- a/include/vara/Feature/Feature.h
+++ b/include/vara/Feature/Feature.h
@@ -92,9 +92,7 @@ public:
   // Locations
   [[nodiscard]] bool hasLocations() const { return !Locations.empty(); }
 
-  void addLocation(FeatureSourceRange &Fsr) {
-    Locations.push_back(std::move(Fsr));
-  }
+  void addLocation(FeatureSourceRange Fsr) { Locations.push_back(Fsr); }
   std::vector<FeatureSourceRange>::iterator
   removeLocation(const FeatureSourceRange &Fsr) {
     return Locations.erase(std::find(Locations.begin(), Locations.end(), Fsr));

--- a/include/vara/Feature/Feature.h
+++ b/include/vara/Feature/Feature.h
@@ -265,7 +265,7 @@ private:
 
 class RootFeature : public Feature {
 public:
-  explicit RootFeature(string Name = "root")
+  explicit RootFeature(string Name)
       : Feature(FeatureKind::FK_ROOT, std::move(Name), false, {}) {}
 
   static bool classof(const Feature *F) {

--- a/include/vara/Feature/Feature.h
+++ b/include/vara/Feature/Feature.h
@@ -92,7 +92,10 @@ public:
   // Locations
   [[nodiscard]] bool hasLocations() const { return !Locations.empty(); }
 
-  void addLocation(FeatureSourceRange Fsr) { Locations.push_back(Fsr); }
+  void addLocation(FeatureSourceRange Fsr) {
+    Locations.push_back(std::move(Fsr));
+  }
+
   std::vector<FeatureSourceRange>::iterator
   removeLocation(const FeatureSourceRange &Fsr) {
     return Locations.erase(std::find(Locations.begin(), Locations.end(), Fsr));

--- a/include/vara/Feature/Feature.h
+++ b/include/vara/Feature/Feature.h
@@ -274,4 +274,16 @@ public:
 
 } // namespace vara::feature
 
+inline std::ostream &operator<<(std::ostream &Out,
+                                const vara::feature::Feature *Feature) {
+  Out << Feature->toString();
+  return Out;
+}
+
+inline llvm::raw_ostream &operator<<(llvm::raw_ostream &Out,
+                                     const vara::feature::Feature *Feature) {
+  Out << Feature->toString();
+  return Out;
+}
+
 #endif // VARA_FEATURE_FEATURE_H

--- a/include/vara/Feature/Feature.h
+++ b/include/vara/Feature/Feature.h
@@ -276,14 +276,14 @@ public:
 } // namespace vara::feature
 
 inline std::ostream &operator<<(std::ostream &Out,
-                                const vara::feature::Feature *Feature) {
-  Out << Feature->toString();
+                                const vara::feature::Feature &Feature) {
+  Out << Feature.toString();
   return Out;
 }
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &Out,
-                                     const vara::feature::Feature *Feature) {
-  Out << Feature->toString();
+                                     const vara::feature::Feature &Feature) {
+  Out << Feature.toString();
   return Out;
 }
 

--- a/include/vara/Feature/FeatureModel.h
+++ b/include/vara/Feature/FeatureModel.h
@@ -58,7 +58,7 @@ public:
 
   [[nodiscard]] llvm::StringRef getCommit() const { return Commit; }
 
-  [[nodiscard]] Feature *getRoot() const { return Root; }
+  [[nodiscard]] RootFeature *getRoot() const { return Root; }
 
   //===--------------------------------------------------------------------===//
   // Ordered feature iterator
@@ -131,7 +131,7 @@ private:
   /// Delete a \a Feature.
   void removeFeature(Feature &Feature);
 
-  RootFeature *setRoot(std::unique_ptr<RootFeature> NewRoot);
+  RootFeature *setRoot(RootFeature &NewRoot);
 
   OrderedFeatureTy OrderedFeatures;
 };

--- a/include/vara/Feature/FeatureModel.h
+++ b/include/vara/Feature/FeatureModel.h
@@ -34,8 +34,7 @@ public:
   using OrderedFeatureTy = OrderedFeatureVector;
   using ConstraintTy = Constraint;
   using ConstraintContainerTy = std::vector<std::unique_ptr<ConstraintTy>>;
-  using RelationshipTy = Relationship;
-  using RelationshipContainerTy = std::vector<std::unique_ptr<RelationshipTy>>;
+  using RelationshipContainerTy = std::vector<std::unique_ptr<Relationship>>;
 
   FeatureModel() = default;
   FeatureModel(std::string Name, fs::path RootPath, std::string Commit,
@@ -126,6 +125,11 @@ private:
   ///
   /// \returns ptr to inserted \a Feature
   Feature *addFeature(std::unique_ptr<Feature> Feature);
+
+  Relationship *addRelationship(std::unique_ptr<Relationship> Relationship) {
+    Relationships.push_back(std::move(Relationship));
+    return Relationships.back().get();
+  }
 
   /// Delete a \a Feature.
   void removeFeature(Feature &Feature);

--- a/include/vara/Feature/FeatureModel.h
+++ b/include/vara/Feature/FeatureModel.h
@@ -360,8 +360,7 @@ struct ExactlyOneRootNode {
          }))) {
       return true;
     }
-    llvm::errs() << "Failed to validate 'CheckFeatureParentChildRelationShip'."
-                 << '\n';
+    llvm::errs() << "Failed to validate 'ExactlyOneRootNode'." << '\n';
     return false;
   }
 };

--- a/include/vara/Feature/FeatureModel.h
+++ b/include/vara/Feature/FeatureModel.h
@@ -254,6 +254,14 @@ private:
     return Relationships.back().get();
   }
 
+  void removeRelationship(Relationship *R) {
+    Relationships.erase(
+        std::find_if(Relationships.begin(), Relationships.end(),
+                     [R](const std::unique_ptr<Relationship> &UniR) {
+                       return UniR.get() == R;
+                     }));
+  }
+
   Constraint *addConstraint(std::unique_ptr<Constraint> Constraint) {
     Constraints.push_back(std::move(Constraint));
     return Constraints.back().get();

--- a/include/vara/Feature/FeatureModel.h
+++ b/include/vara/Feature/FeatureModel.h
@@ -131,12 +131,19 @@ private:
     return Relationships.back().get();
   }
 
+  Constraint *addConstraint(std::unique_ptr<Constraint> Constraint) {
+    Constraints.push_back(std::move(Constraint));
+    return Constraints.back().get();
+  }
+
   /// Delete a \a Feature.
   void removeFeature(Feature &Feature);
 
   RootFeature *setRoot(RootFeature &NewRoot);
 
   void setName(std::string NewName) { Name = std::move(NewName); }
+
+  void setCommit(std::string NewCommit) { Commit = std::move(NewCommit); }
 
   void setPath(fs::path NewPath) { Path = std::move(NewPath); }
 
@@ -345,10 +352,11 @@ struct CheckFeatureParentChildRelationShip {
 
 struct ExactlyOneRootNode {
   static bool check(FeatureModel &FM) {
-    if (llvm::isa_and_nonnull<RootFeature>(FM.getRoot()) &&
-        1 == std::accumulate(FM.begin(), FM.end(), 0, [](int Sum, Feature *F) {
-          return Sum + llvm::isa<RootFeature>(F);
-        })) {
+    if ((!FM.getRoot() && FM.size() == 0) ||
+        (llvm::isa_and_nonnull<RootFeature>(FM.getRoot()) &&
+         1 == std::accumulate(FM.begin(), FM.end(), 0, [](int Sum, Feature *F) {
+           return Sum + llvm::isa<RootFeature>(F);
+         }))) {
       return true;
     }
     llvm::errs() << "Failed to validate 'CheckFeatureParentChildRelationShip'."

--- a/include/vara/Feature/FeatureModel.h
+++ b/include/vara/Feature/FeatureModel.h
@@ -2,8 +2,7 @@
 #define VARA_FEATURE_FEATUREMODEL_H
 
 #include "vara/Feature/Constraint.h"
-#include "vara/Feature/FeatureTreeNode.h"
-#include "vara/Feature/OrderedFeatureVector.h"
+#include "vara/Feature/Feature.h"
 #include "vara/Feature/Relationship.h"
 
 #include "llvm/ADT/SmallSet.h"
@@ -31,7 +30,6 @@ class FeatureModel {
 
 public:
   using FeatureMapTy = llvm::StringMap<std::unique_ptr<Feature>>;
-  using OrderedFeatureTy = OrderedFeatureVector;
   using ConstraintTy = Constraint;
   using ConstraintContainerTy = std::vector<std::unique_ptr<ConstraintTy>>;
   using RelationshipContainerTy = std::vector<std::unique_ptr<Relationship>>;
@@ -43,12 +41,7 @@ public:
       : Name(std::move(Name)), Path(std::move(RootPath)),
         Commit(std::move(Commit)), Features(std::move(Features)),
         Constraints(std::move(Constraints)),
-        Relationships(std::move(Relationships)), Root(Root) {
-    // Insert all values into ordered data structure.
-    for (const auto &KV : this->Features) {
-      OrderedFeatures.insert(KV.getValue().get());
-    }
-  }
+        Relationships(std::move(Relationships)), Root(Root) {}
 
   [[nodiscard]] unsigned int size() { return Features.size(); }
 
@@ -64,31 +57,157 @@ public:
   void setCommit(std::string NewCommit) { Commit = std::move(NewCommit); }
 
   //===--------------------------------------------------------------------===//
-  // Ordered feature iterator
-  OrderedFeatureVector::ordered_feature_iterator begin() {
-    return OrderedFeatures.begin();
-  }
-  [[nodiscard]] OrderedFeatureVector::const_ordered_feature_iterator
-  begin() const {
-    return OrderedFeatures.begin();
+  // DFS feature iterator
+
+  class DFSIterator : public std::iterator<std::forward_iterator_tag, Feature *,
+                                           ptrdiff_t, Feature **, Feature *> {
+
+  public:
+    DFSIterator(Feature *F = nullptr) {
+      if (F) {
+        Frontier.push(F);
+      }
+    }
+    DFSIterator(const DFSIterator &) = default;
+    DFSIterator &operator=(const DFSIterator &) = delete;
+    DFSIterator(DFSIterator &&) = default;
+    DFSIterator &operator=(DFSIterator &&) = delete;
+    ~DFSIterator() = default;
+
+    reference operator*() {
+      return Frontier.empty() ? nullptr : Frontier.top();
+    }
+
+    pointer operator->() {
+      return Frontier.empty() ? nullptr : &Frontier.top();
+    }
+
+    DFSIterator operator++() {
+      if (Frontier.empty()) {
+        return *this;
+      }
+      auto *F = Frontier.top();
+      Frontier.pop();
+      if (F) {
+        Visited.insert(F);
+        llvm::SmallVector<Feature *, 3> Children;
+        for (auto *C : F->getChildren<Feature>()) {
+          Children.insert(std::upper_bound(Children.begin(), Children.end(), C,
+                                           [](Feature *A, Feature *B) {
+                                             return A->getName().lower() >
+                                                    B->getName().lower();
+                                             ;
+                                           }),
+                          C);
+        }
+        std::for_each(Children.begin(), Children.end(), [this](Feature *C) {
+          if (Visited.find(C) == Visited.end()) {
+            Frontier.push(C);
+          }
+        });
+      }
+      return *this;
+    }
+
+    DFSIterator operator++(int) {
+      auto Iter(*this);
+      ++*this;
+      return Iter;
+    }
+
+    bool operator==(const DFSIterator &Other) const {
+      if (Frontier.empty() || Other.Frontier.empty()) {
+        return Frontier.empty() && Other.Frontier.empty();
+      }
+      return *this->Frontier.top() == *Other.Frontier.top();
+    };
+
+    bool operator!=(const DFSIterator &Other) const {
+      return !(*this == Other);
+    };
+
+  private:
+    std::stack<Feature *> Frontier;
+    std::set<Feature *> Visited;
+  };
+
+  using ordered_feature_iterator = DFSIterator;
+  using const_ordered_feature_iterator = DFSIterator;
+
+  ordered_feature_iterator begin() { return DFSIterator(Root); }
+  [[nodiscard]] const_ordered_feature_iterator begin() const {
+    return DFSIterator(Root);
   }
 
-  OrderedFeatureVector::ordered_feature_iterator end() {
-    return OrderedFeatures.end();
+  ordered_feature_iterator end() {
+    return DFSIterator(Root ? Root->getParentFeature() : nullptr);
   }
-  [[nodiscard]] OrderedFeatureVector::const_ordered_feature_iterator
-  end() const {
-    return OrderedFeatures.end();
+  [[nodiscard]] const_ordered_feature_iterator end() const {
+    return DFSIterator(Root ? Root->getParentFeature() : nullptr);
   }
 
-  llvm::iterator_range<OrderedFeatureVector::ordered_feature_iterator>
-  features() {
+  llvm::iterator_range<ordered_feature_iterator> features() {
     return llvm::make_range(begin(), end());
   }
-  [[nodiscard]] llvm::iterator_range<
-      OrderedFeatureVector::const_ordered_feature_iterator>
+  [[nodiscard]] llvm::iterator_range<const_ordered_feature_iterator>
   features() const {
     return llvm::make_range(begin(), end());
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Unordered feature iterator
+
+  class FeatureMapIterator
+      : public std::iterator<std::forward_iterator_tag, Feature *, ptrdiff_t,
+                             Feature *, Feature *> {
+
+  public:
+    FeatureMapIterator(FeatureMapTy::const_iterator MapIter)
+        : MapIter(MapIter) {}
+    FeatureMapIterator(const FeatureMapIterator &) = default;
+    FeatureMapIterator &operator=(const FeatureMapIterator &) = delete;
+    FeatureMapIterator(FeatureMapIterator &&) = default;
+    FeatureMapIterator &operator=(FeatureMapIterator &&) = delete;
+    ~FeatureMapIterator() = default;
+
+    reference operator*() { return MapIter->getValue().get(); }
+
+    pointer operator->() { return **this; }
+
+    FeatureMapIterator operator++() {
+      ++MapIter;
+      return *this;
+    }
+
+    FeatureMapIterator operator++(int) {
+      auto Iter(*this);
+      ++*this;
+      return Iter;
+    }
+
+    bool operator==(const FeatureMapIterator &Other) const {
+      return MapIter == Other.MapIter;
+    };
+
+    bool operator!=(const FeatureMapIterator &Other) const {
+      return !(*this == Other);
+    };
+
+  private:
+    FeatureMapTy::const_iterator MapIter;
+  };
+
+  using unordered_feature_iterator = FeatureMapIterator;
+  using const_unordered_feature_iterator = FeatureMapIterator;
+
+  llvm::iterator_range<unordered_feature_iterator> unordered_features() {
+    return llvm::make_range(FeatureMapIterator(Features.begin()),
+                            FeatureMapIterator(Features.end()));
+  }
+  [[nodiscard]] llvm::iterator_range<const_unordered_feature_iterator>
+  unordered_features() const {
+    return llvm::make_range(FeatureMapIterator(Features.begin()),
+                            FeatureMapIterator(Features.end()));
   }
 
   //===--------------------------------------------------------------------===//
@@ -147,10 +266,6 @@ private:
   void setName(std::string NewName) { Name = std::move(NewName); }
 
   void setPath(fs::path NewPath) { Path = std::move(NewPath); }
-
-  void sort() { OrderedFeatures.sort(); }
-
-  OrderedFeatureTy OrderedFeatures;
 };
 
 } // namespace vara::feature
@@ -324,9 +439,10 @@ public:
 
 struct EveryFeatureRequiresParent {
   static bool check(FeatureModel &FM) {
-    if (std::all_of(FM.begin(), FM.end(), [](Feature *F) {
-          return llvm::isa<RootFeature>(F) || F->getParentFeature();
-        })) {
+    if (std::all_of(FM.unordered_features().begin(),
+                    FM.unordered_features().end(), [](Feature *F) {
+                      return llvm::isa<RootFeature>(F) || F->getParentFeature();
+                    })) {
       return true;
     }
     llvm::errs() << "Failed to validate 'EveryFeatureRequiresParent'." << '\n';
@@ -336,13 +452,15 @@ struct EveryFeatureRequiresParent {
 
 struct CheckFeatureParentChildRelationShip {
   static bool check(FeatureModel &FM) {
-    if (std::all_of(FM.begin(), FM.end(), [](Feature *F) {
-          return llvm::isa<RootFeature>(F) ||
-                 // Every parent of a Feature needs to have it as a child.
-                 std::any_of(
-                     F->getParent()->begin(), F->getParent()->end(),
-                     [F](FeatureTreeNode *Child) { return F == Child; });
-        })) {
+    if (std::all_of(
+            FM.unordered_features().begin(), FM.unordered_features().end(),
+            [](Feature *F) {
+              return llvm::isa<RootFeature>(F) ||
+                     // Every parent of a Feature needs to have it as a child.
+                     std::any_of(
+                         F->getParent()->begin(), F->getParent()->end(),
+                         [F](FeatureTreeNode *Child) { return F == Child; });
+            })) {
       return true;
     }
     llvm::errs() << "Failed to validate 'CheckFeatureParentChildRelationShip'."
@@ -355,9 +473,11 @@ struct ExactlyOneRootNode {
   static bool check(FeatureModel &FM) {
     if ((!FM.getRoot() && FM.size() == 0) ||
         (llvm::isa_and_nonnull<RootFeature>(FM.getRoot()) &&
-         1 == std::accumulate(FM.begin(), FM.end(), 0, [](int Sum, Feature *F) {
-           return Sum + llvm::isa<RootFeature>(F);
-         }))) {
+         1 == std::accumulate(FM.unordered_features().begin(),
+                              FM.unordered_features().end(), 0,
+                              [](int Sum, Feature *F) {
+                                return Sum + llvm::isa<RootFeature>(F);
+                              }))) {
       return true;
     }
     llvm::errs() << "Failed to validate 'ExactlyOneRootNode'." << '\n';

--- a/include/vara/Feature/FeatureModel.h
+++ b/include/vara/Feature/FeatureModel.h
@@ -54,9 +54,6 @@ public:
 
   [[nodiscard]] RootFeature *getRoot() const { return Root; }
 
-  // TODO make this private and use a transaction
-  void setCommit(std::string NewCommit) { Commit = std::move(NewCommit); }
-
   //===--------------------------------------------------------------------===//
   // DFS feature iterator
 
@@ -232,15 +229,6 @@ public:
   LLVM_DUMP_METHOD
   void dump() const;
 
-protected:
-  std::string Name;
-  RootFeature *Root;
-  fs::path Path;
-  std::string Commit;
-  FeatureMapTy Features;
-  ConstraintContainerTy Constraints;
-  RelationshipContainerTy Relationships;
-
 private:
   /// Insert a \a Feature into existing model.
   ///
@@ -275,6 +263,16 @@ private:
   void setName(std::string NewName) { Name = std::move(NewName); }
 
   void setPath(fs::path NewPath) { Path = std::move(NewPath); }
+
+  void setCommit(std::string NewCommit) { Commit = std::move(NewCommit); }
+
+  std::string Name;
+  RootFeature *Root;
+  fs::path Path;
+  std::string Commit;
+  FeatureMapTy Features;
+  ConstraintContainerTy Constraints;
+  RelationshipContainerTy Relationships;
 };
 
 } // namespace vara::feature

--- a/include/vara/Feature/FeatureModel.h
+++ b/include/vara/Feature/FeatureModel.h
@@ -128,6 +128,11 @@ private:
   /// \returns ptr to inserted \a Feature
   Feature *addFeature(std::unique_ptr<Feature> Feature);
 
+  /// Add a \a Relationship into existing model.
+  ///
+  /// \param Relationship Relationship to be inserted
+  RelationshipTy *addRelationship(std::unique_ptr<RelationshipTy> Relationship);
+
   /// Delete a \a Feature.
   void removeFeature(Feature &Feature);
 

--- a/include/vara/Feature/FeatureModelBuilder.h
+++ b/include/vara/Feature/FeatureModelBuilder.h
@@ -1,0 +1,141 @@
+#ifndef VARA_FEATURE_FEATUREMODELBUILDER_H
+#define VARA_FEATURE_FEATUREMODELBUILDER_H
+
+#include "vara/Feature/FeatureModel.h"
+#include "vara/Feature/FeatureModelTransaction.h"
+
+namespace vara::feature {
+
+//===----------------------------------------------------------------------===//
+//                        FeatureModelBuilder
+//===----------------------------------------------------------------------===//
+
+/// \brief Builder for \a FeatureModel which can be used while parsing.
+class FeatureModelBuilder : private FeatureModel {
+public:
+  FeatureModelBuilder() { init(); }
+
+  void init() {
+    Name = "";
+    Path = "";
+    Commit = "";
+    Features.clear();
+    Constraints.clear();
+    Parents.clear();
+    Children.clear();
+    auto FMT = FeatureModelModifyTransaction::openTransaction(*this);
+    FMT.setRoot(std::make_unique<RootFeature>(RootName));
+    FMT.commit();
+  }
+
+  /// Try to create a new \a Feature.
+  ///
+  /// \param[in] FeatureName name of the \a Feature
+  /// \param[in] FurtherArgs further arguments that should be passed to the
+  ///                        \a Feature constructor
+  ///
+  /// \returns ptr to inserted \a Feature
+  template <
+      typename FeatureTy, typename... Args,
+      std::enable_if_t<std::is_base_of_v<Feature, FeatureTy>, bool> = true>
+  FeatureTy *makeFeature(std::string FeatureName, Args &&...FurtherArgs) {
+    auto FMT = FeatureModelModifyTransaction::openTransaction(*this);
+    FMT.addFeature(std::make_unique<FeatureTy>(
+        FeatureName, std::forward<Args>(FurtherArgs)...));
+    FMT.commit();
+    return llvm::dyn_cast<FeatureTy>(getFeature(FeatureName));
+  }
+
+  FeatureModelBuilder *addEdge(const std::string &ParentName,
+                               const std::string &FeatureName) {
+    Children[ParentName].insert(FeatureName);
+    Parents[FeatureName] = ParentName;
+    return this;
+  }
+
+  FeatureModelBuilder *
+  emplaceRelationship(Relationship::RelationshipKind RK,
+                      const std::vector<std::string> &FeatureNames,
+                      const std::string &ParentName) {
+    RelationshipEdges[ParentName].emplace_back(RK, FeatureNames);
+    return this;
+  }
+
+  FeatureModelBuilder *
+  addConstraint(std::unique_ptr<FeatureModel::ConstraintTy> C) {
+    Constraints.push_back(std::move(C));
+    return this;
+  }
+
+  FeatureModelBuilder *setVmName(std::string Name) {
+    this->Name = std::move(Name);
+    return this;
+  }
+
+  FeatureModelBuilder *setPath(fs::path Path) {
+    this->Path = std::move(Path);
+    return this;
+  }
+
+  FeatureModelBuilder *setCommit(std::string Commit) {
+    this->Commit = std::move(Commit);
+    return this;
+  }
+
+  FeatureModelBuilder *setRoot(std::string Name) {
+    this->RootName = std::move(Name);
+    auto FMT = FeatureModelModifyTransaction::openTransaction(*this);
+    FMT.setRoot(std::make_unique<RootFeature>(RootName));
+    // TODO(s9latimm) remove old root
+    FMT.commit();
+    return this;
+  }
+
+  /// Build \a FeatureModel.
+  ///
+  /// \return instance of \a FeatureModel
+  std::unique_ptr<FeatureModel> buildFeatureModel();
+
+private:
+  class BuilderVisitor : public ConstraintVisitor {
+
+  public:
+    BuilderVisitor(FeatureModelBuilder *Builder) : Builder(Builder) {}
+
+    void visit(PrimaryFeatureConstraint *C) override {
+      auto *F = Builder->getFeature(C->getFeature()->getName());
+      C->setFeature(F);
+      F->addConstraint(C);
+    };
+
+  private:
+    FeatureModelBuilder *Builder;
+  };
+
+  using EdgeMapType = typename llvm::StringMap<llvm::SmallSet<std::string, 3>>;
+  using RelationshipEdgeType = typename llvm::StringMap<std::vector<
+      std::pair<Relationship::RelationshipKind, std::vector<std::string>>>>;
+
+  FeatureModel::ConstraintContainerTy Constraints;
+  FeatureModel::RelationshipContainerTy Relationships;
+  llvm::StringMap<std::string> Parents;
+  EdgeMapType Children;
+  RelationshipEdgeType RelationshipEdges;
+  std::string RootName{"root"};
+
+  bool buildConstraints();
+
+  /// This method is solely relevant for parsing XML, as alternatives are
+  /// represented als mutual excluded but non-optional features (which requires
+  /// additional processing).
+  void detectXMLAlternatives();
+
+  bool buildRoot();
+
+  bool buildTree(const std::string &FeatureName,
+                 std::set<std::string> &Visited);
+};
+
+} // namespace vara::feature
+
+#endif // VARA_FEATURE_FEATUREMODELBUILDER_H

--- a/include/vara/Feature/FeatureModelBuilder.h
+++ b/include/vara/Feature/FeatureModelBuilder.h
@@ -19,8 +19,7 @@ public:
       : FM(std::make_unique<FeatureModel>()),
         Features(FeatureModelModifyTransaction::openTransaction(*FM)),
         Transactions(FeatureModelModifyTransaction::openTransaction(*FM)),
-        PostTransactions(FeatureModelModifyTransaction::openTransaction(*FM)),
-        Special(FeatureModelModifyTransaction::openTransaction(*FM)) {}
+        PostTransactions(FeatureModelModifyTransaction::openTransaction(*FM)) {}
 
   /// Try to create a new \a Feature.
   ///
@@ -87,12 +86,6 @@ private:
   FeatureModelTransaction<detail::ModifyTransactionMode> Features;
   FeatureModelTransaction<detail::ModifyTransactionMode> Transactions;
   FeatureModelTransaction<detail::ModifyTransactionMode> PostTransactions;
-  FeatureModelTransaction<detail::ModifyTransactionMode> Special;
-
-  /// This method is solely relevant for parsing XML, as alternatives are
-  /// represented als mutual excluded but non-optional features (which requires
-  /// additional processing).
-  bool detectXMLAlternatives();
 };
 
 } // namespace vara::feature

--- a/include/vara/Feature/FeatureModelBuilder.h
+++ b/include/vara/Feature/FeatureModelBuilder.h
@@ -1,6 +1,8 @@
 #ifndef VARA_FEATURE_FEATUREMODELBUILDER_H
 #define VARA_FEATURE_FEATUREMODELBUILDER_H
 
+#include <utility>
+
 #include "vara/Feature/FeatureModel.h"
 #include "vara/Feature/FeatureModelTransaction.h"
 
@@ -11,13 +13,12 @@ namespace vara::feature {
 //===----------------------------------------------------------------------===//
 
 /// \brief Builder for \a FeatureModel which can be used while parsing.
-class FeatureModelBuilder : private FeatureModel {
+class FeatureModelBuilder {
 public:
-  FeatureModelBuilder() {
-    auto FMT = FeatureModelModifyTransaction::openTransaction(*this);
-    FMT.setRoot(std::make_unique<RootFeature>("root"));
-    FMT.commit();
-  }
+  FeatureModelBuilder()
+      : FM(std::make_unique<FeatureModel>()),
+        Features(FeatureModelModifyTransaction::openTransaction(*FM)),
+        Transactions(FeatureModelModifyTransaction::openTransaction(*FM)) {}
 
   /// Try to create a new \a Feature.
   ///
@@ -25,22 +26,20 @@ public:
   /// \param[in] FurtherArgs further arguments that should be passed to the
   ///                        \a Feature constructor
   ///
-  /// \returns ptr to inserted \a Feature
+  /// \returns FeatureModelBuilder
   template <
       typename FeatureTy, typename... Args,
       std::enable_if_t<std::is_base_of_v<Feature, FeatureTy>, bool> = true>
-  FeatureTy *makeFeature(std::string FeatureName, Args &&...FurtherArgs) {
-    auto FMT = FeatureModelModifyTransaction::openTransaction(*this);
-    FMT.addFeature(std::make_unique<FeatureTy>(
+  FeatureModelBuilder *makeFeature(std::string FeatureName,
+                                   Args &&...FurtherArgs) {
+    Features.addFeature(std::make_unique<FeatureTy>(
         FeatureName, std::forward<Args>(FurtherArgs)...));
-    return FMT.commit() ? llvm::dyn_cast<FeatureTy>(getFeature(FeatureName))
-                        : nullptr;
+    return this;
   }
 
   FeatureModelBuilder *addEdge(const std::string &ParentName,
                                const std::string &FeatureName) {
-    Children[ParentName].insert(FeatureName);
-    Parents[FeatureName] = ParentName;
+    Transactions.addChild(ParentName, FeatureName);
     return this;
   }
 
@@ -59,24 +58,22 @@ public:
   }
 
   FeatureModelBuilder *setVmName(std::string Name) {
-    this->Name = std::move(Name);
+    Transactions.setName(std::move(Name));
     return this;
   }
 
-  FeatureModelBuilder *setPath(fs::path Path) {
-    this->Path = std::move(Path);
+  FeatureModelBuilder *setPath(const fs::path &Path) {
+    Transactions.setPath(Path);
     return this;
   }
 
   FeatureModelBuilder *setCommit(std::string Commit) {
-    this->Commit = std::move(Commit);
+    //    this->Commit = std::move(Commit);
     return this;
   }
 
   FeatureModelBuilder *setRoot(const std::string &Name) {
-    auto FMT = FeatureModelModifyTransaction::openTransaction(*this);
-    FMT.setRoot(std::make_unique<RootFeature>(Name));
-    FMT.commit();
+    Transactions.setRoot(std::make_unique<RootFeature>(Name));
     return this;
   }
 
@@ -89,26 +86,27 @@ private:
   class BuilderVisitor : public ConstraintVisitor {
 
   public:
-    BuilderVisitor(FeatureModelBuilder *Builder) : Builder(Builder) {}
+    BuilderVisitor(FeatureModelBuilder &Builder) : Builder(Builder) {}
 
     void visit(PrimaryFeatureConstraint *C) override {
-      auto *F = Builder->getFeature(C->getFeature()->getName());
+      auto *F = Builder.FM->getFeature(C->getFeature()->getName());
       C->setFeature(F);
       F->addConstraint(C);
     };
 
   private:
-    FeatureModelBuilder *Builder;
+    FeatureModelBuilder &Builder;
   };
 
-  using EdgeMapType = typename llvm::StringMap<llvm::SmallSet<std::string, 3>>;
+  std::unique_ptr<FeatureModel> FM;
+  FeatureModelTransaction<detail::ModifyTransactionMode> Features;
+  FeatureModelTransaction<detail::ModifyTransactionMode> Transactions;
+
   using RelationshipEdgeType = typename llvm::StringMap<std::vector<
       std::pair<Relationship::RelationshipKind, std::vector<std::string>>>>;
 
   FeatureModel::ConstraintContainerTy Constraints;
   FeatureModel::RelationshipContainerTy Relationships;
-  llvm::StringMap<std::string> Parents;
-  EdgeMapType Children;
   RelationshipEdgeType RelationshipEdges;
 
   bool buildConstraints();

--- a/include/vara/Feature/FeatureModelBuilder.h
+++ b/include/vara/Feature/FeatureModelBuilder.h
@@ -68,7 +68,7 @@ public:
   }
 
   FeatureModelBuilder *setCommit(std::string Commit) {
-    Transactions.setCommit(Commit);
+    Transactions.setCommit(std::move(Commit));
     return this;
   }
 

--- a/include/vara/Feature/FeatureModelBuilder.h
+++ b/include/vara/Feature/FeatureModelBuilder.h
@@ -18,7 +18,8 @@ public:
   FeatureModelBuilder()
       : FM(std::make_unique<FeatureModel>()),
         Features(FeatureModelModifyTransaction::openTransaction(*FM)),
-        Transactions(FeatureModelModifyTransaction::openTransaction(*FM)) {}
+        Transactions(FeatureModelModifyTransaction::openTransaction(*FM)),
+        PostTransactions(FeatureModelModifyTransaction::openTransaction(*FM)) {}
 
   /// Try to create a new \a Feature.
   ///
@@ -47,7 +48,9 @@ public:
   emplaceRelationship(Relationship::RelationshipKind RK,
                       const std::vector<std::string> &FeatureNames,
                       const std::string &ParentName) {
-    RelationshipEdges[ParentName].emplace_back(RK, FeatureNames);
+    PostTransactions.addRelationship(
+        RK, ParentName,
+        std::set<std::string>(FeatureNames.begin(), FeatureNames.end()));
     return this;
   }
 
@@ -101,6 +104,7 @@ private:
   std::unique_ptr<FeatureModel> FM;
   FeatureModelTransaction<detail::ModifyTransactionMode> Features;
   FeatureModelTransaction<detail::ModifyTransactionMode> Transactions;
+  FeatureModelTransaction<detail::ModifyTransactionMode> PostTransactions;
 
   using RelationshipEdgeType = typename llvm::StringMap<std::vector<
       std::pair<Relationship::RelationshipKind, std::vector<std::string>>>>;

--- a/include/vara/Feature/FeatureModelBuilder.h
+++ b/include/vara/Feature/FeatureModelBuilder.h
@@ -45,13 +45,9 @@ public:
     return this;
   }
 
-  FeatureModelBuilder *
-  emplaceRelationship(Relationship::RelationshipKind RK,
-                      const std::vector<std::string> &FeatureNames,
-                      const std::string &ParentName) {
-    PostTransactions.addRelationship(
-        RK, ParentName,
-        std::set<std::string>(FeatureNames.begin(), FeatureNames.end()));
+  FeatureModelBuilder *emplaceRelationship(Relationship::RelationshipKind RK,
+                                           const std::string &ParentName) {
+    PostTransactions.addRelationship(RK, ParentName);
     return this;
   }
 

--- a/include/vara/Feature/FeatureModelParser.h
+++ b/include/vara/Feature/FeatureModelParser.h
@@ -1,7 +1,7 @@
 #ifndef VARA_FEATURE_FEATUREMODELPARSER_H
 #define VARA_FEATURE_FEATUREMODELPARSER_H
 
-#include "vara/Feature/FeatureModel.h"
+#include "vara/Feature/FeatureModelBuilder.h"
 
 #include "libxml/parser.h"
 #include "libxml/tree.h"

--- a/include/vara/Feature/FeatureModelParser.h
+++ b/include/vara/Feature/FeatureModelParser.h
@@ -50,6 +50,11 @@ public:
 
   bool verifyFeatureModel() override;
 
+  /// This method is solely relevant for parsing XML, as alternatives are
+  /// represented als mutual excluded but non-optional features (which requires
+  /// additional processing).
+  static bool detectXMLAlternatives(FeatureModel &FM);
+
 private:
   std::string Xml;
   FeatureModelBuilder FMB;

--- a/include/vara/Feature/FeatureModelTransaction.h
+++ b/include/vara/Feature/FeatureModelTransaction.h
@@ -112,6 +112,17 @@ using FeatureModelModifyTransaction =
 void addFeature(FeatureModel *FM, std::unique_ptr<Feature> NewFeature,
                 Feature *Parent = nullptr);
 
+/// Merges a FeatureModel into another
+///
+/// Merging fails if both FeatureModels contain a Feature with equal name,
+/// but different properties.
+///
+/// \param FM1
+/// \param FM2
+/// \return New merged FeatureModel or nullptr if merging failed
+[[nodiscard]] std::unique_ptr<FeatureModel>
+mergeFeatureModels(FeatureModel &FM1, FeatureModel &FM2);
+
 //===----------------------------------------------------------------------===//
 //                    Transaction Implementation Details
 //===----------------------------------------------------------------------===//

--- a/include/vara/Feature/FeatureModelTransaction.h
+++ b/include/vara/Feature/FeatureModelTransaction.h
@@ -708,6 +708,33 @@ private:
 
 } // namespace detail
 
+//===----------------------------------------------------------------------===//
+//                            Modification Helpers
+//===----------------------------------------------------------------------===//
+
+/// Adds a Feature to the FeatureModel
+///
+/// If a Parent is passed it needs to be already in the FeatureModel,
+/// otherwise, root is assumed as the parent Feature.
+///
+/// \param FM
+/// \param NewFeature
+/// \param Parent of the new feature
+void addFeature(FeatureModel *FM, std::unique_ptr<Feature> NewFeature,
+                Feature *Parent = nullptr);
+
+/// Merges a FeatureModel into another
+///
+/// Merging fails if both FeatureModels contain a Feature with equal name,
+/// but different properties.
+///
+/// \param FM1
+/// \param FM2
+///
+/// \return New merged FeatureModel or nullptr if merging failed
+[[nodiscard]] std::unique_ptr<FeatureModel>
+mergeFeatureModels(FeatureModel &FM1, FeatureModel &FM2);
+
 } // namespace vara::feature
 
 #endif // VARA_FEATURE_FEATUREMODELTRANSACTION_H

--- a/include/vara/Feature/FeatureModelTransaction.h
+++ b/include/vara/Feature/FeatureModelTransaction.h
@@ -68,7 +68,7 @@ public:
         //  before destruction
         llvm::errs()
             << "warning: Uncommitted modifications before destruction.\n";
-        // TODO(se-passau/VaRA/issues/744): Committing now may break with prior
+        // TODO(se-passau/VaRA#744): Committing now may break with prior
         //  failed commits. We need a better way of tracking if a previous
         //  commit failed, instead of checking locally if FM is nullptr.
         commit();

--- a/include/vara/Feature/FeatureModelTransaction.h
+++ b/include/vara/Feature/FeatureModelTransaction.h
@@ -598,7 +598,7 @@ protected:
   }
 
   void addLocationImpl(const FeatureVariantTy &F, FeatureSourceRange FSR) {
-    assert(FM && "");
+    assert(FM && "FeatureModel is null.");
 
     FeatureModelModification::make_modification<AddLocationToFeature>(
         F, std::move(FSR))(*FM);
@@ -614,20 +614,20 @@ protected:
   }
 
   void setNameImpl(std::string Name) {
-    assert(FM && "");
+    assert(FM && "FeatureModel is null.");
 
     FeatureModelModification::make_modification<SetName>(std::move(Name))(*FM);
   }
 
   void setCommitImpl(std::string Commit) {
-    assert(FM && "");
+    assert(FM && "FeatureModel is null.");
 
     FeatureModelModification::make_modification<SetCommit>(std::move(Commit))(
         *FM);
   }
 
   void setPathImpl(fs::path Path) {
-    assert(FM && "");
+    assert(FM && "FeatureModel is null.");
 
     FeatureModelModification::make_modification<SetPath>(std::move(Path))(*FM);
   }
@@ -683,7 +683,7 @@ protected:
   // Modifications
 
   void addFeatureImpl(std::unique_ptr<Feature> NewFeature, Feature *Parent) {
-    assert(FM && "");
+    assert(FM && "FeatureModel is null.");
 
     Modifications.push_back(
         FeatureModelModification::make_unique_modification<AddFeatureToModel>(
@@ -707,7 +707,7 @@ protected:
   }
 
   void setNameImpl(std::string Name) {
-    assert(FM && "");
+    assert(FM && "FeatureModel is null.");
 
     Modifications.push_back(
         FeatureModelModification::make_unique_modification<SetName>(
@@ -715,7 +715,7 @@ protected:
   }
 
   void setCommitImpl(std::string Commit) {
-    assert(FM && "");
+    assert(FM && "FeatureModel is null.");
 
     Modifications.push_back(
         FeatureModelModification::make_unique_modification<SetCommit>(
@@ -723,7 +723,7 @@ protected:
   }
 
   void setPathImpl(fs::path Path) {
-    assert(FM && "");
+    assert(FM && "FeatureModel is null.");
 
     Modifications.push_back(
         FeatureModelModification::make_unique_modification<SetPath>(
@@ -731,7 +731,7 @@ protected:
   }
 
   void setRootImpl(std::unique_ptr<RootFeature> Root) {
-    assert(FM && "");
+    assert(FM && "FeatureModel is null.");
 
     Modifications.push_back(
         FeatureModelModification::make_unique_modification<SetRoot>(
@@ -740,7 +740,7 @@ protected:
 
   void addChildImpl(const FeatureTreeNodeVariantTy &Parent,
                     const FeatureTreeNodeVariantTy &Child) {
-    assert(FM && "");
+    assert(FM && "FeatureModel is null.");
 
     Modifications.push_back(
         FeatureModelModification::make_unique_modification<AddChild>(Parent,

--- a/include/vara/Feature/FeatureModelTransaction.h
+++ b/include/vara/Feature/FeatureModelTransaction.h
@@ -200,7 +200,7 @@ protected:
   }
 
   static void addLocation(Feature &F, FeatureSourceRange FSR) {
-    F.addLocation(FSR);
+    F.addLocation(std::move(FSR));
   }
 
   static void setFeature(PrimaryFeatureConstraint &Constraint, Feature &F) {

--- a/include/vara/Feature/FeatureModelTransaction.h
+++ b/include/vara/Feature/FeatureModelTransaction.h
@@ -63,13 +63,14 @@ public:
       assert(!this->isUncommitted() &&
              "Transaction in CopyMode should be commited before destruction.");
     } else {
-      if (this->isUncommitted()) { // In modification mode we should ensure that
-                                   // changes are committed before destruction
+      if (this->isUncommitted()) {
+        // In modification mode we should ensure that changes are committed
+        //  before destruction
         llvm::errs()
             << "warning: Uncommitted modifications before destruction.\n";
-        // TODO(s9latimm): Committing now may break with prior failed commits.
-        //  We need a better way of tracking if a previous commit failed,
-        //  instead of checking locally if FM is nullptr.
+        // TODO(se-passau/VaRA/issues/744): Committing now may break with prior
+        //  failed commits. We need a better way of tracking if a previous
+        //  commit failed, instead of checking locally if FM is nullptr.
         commit();
       }
     }
@@ -440,7 +441,7 @@ public:
         },
         Parent);
     if (!P) {
-      // TODO handle this
+      // TODO(se-passau/VaRA#744) handle this
       return;
     }
 
@@ -976,8 +977,14 @@ private:
 /// \param FM
 /// \param NewFeature
 /// \param Parent of the new feature
-void addFeature(FeatureModel *FM, std::unique_ptr<Feature> NewFeature,
+void addFeature(FeatureModel &FM, std::unique_ptr<Feature> NewFeature,
                 Feature *Parent = nullptr);
+
+/// Set commit of a FeatureModel.
+///
+/// \param FM
+/// \param NewCommit
+void setCommit(FeatureModel &FM, std::string NewCommit);
 
 /// Merges a FeatureModel into another
 ///

--- a/include/vara/Feature/FeatureModelTransaction.h
+++ b/include/vara/Feature/FeatureModelTransaction.h
@@ -605,7 +605,14 @@ protected:
     assert(FM && "");
 
     FeatureModelModification::make_modification<AddLocationToFeature>(
-        F, std::move(FSR))(*FM);
+        TranslateFeature(*std::visit(Overloaded{
+                                         [this](const std::string &Name) {
+                                           return FM->getFeature(Name);
+                                         },
+                                         [](Feature *Ptr) { return Ptr; },
+                                     },
+                                     F)),
+        std::move(FSR))(*FM);
   }
 
   Constraint *addConstraintImpl(std::unique_ptr<Constraint> NewConstraint) {

--- a/include/vara/Feature/FeatureModelTransaction.h
+++ b/include/vara/Feature/FeatureModelTransaction.h
@@ -247,8 +247,6 @@ protected:
     return FM.setRoot(NewRoot);
   }
 
-  static void sort(FeatureModel &FM) { FM.sort(); }
-
   /// \brief Remove \a Feature from a \a FeatureModel.
   ///
   /// \param FM model to remove from
@@ -497,7 +495,6 @@ public:
       }
       setRoot(FM, *NewRoot);
     }
-    sort(FM);
     return FM.getRoot();
   }
 
@@ -539,7 +536,6 @@ public:
     removeEdge(*C->getParent(), *C);
     addEdge(*P, *C);
     setParent(*C, *P);
-    sort(FM);
   }
 
 private:

--- a/include/vara/Feature/FeatureModelTransaction.h
+++ b/include/vara/Feature/FeatureModelTransaction.h
@@ -339,13 +339,14 @@ public:
         },
         GroupRoot);
     if (!F) {
-      // TODO handle this
+      // TODO (se-passau/VaRA#744): error, does not exist
       return;
     }
 
     if (Recursive) {
       for (auto *C : F->getChildren<Feature>()) {
-        //
+        // TODO (se-passau/VaRA#744): error, if call returns error (should not
+        // be possible)
         RemoveFeatureFromModel(C, Recursive)(FM);
       }
       for (auto *R : F->getChildren<Relationship>()) {
@@ -354,7 +355,8 @@ public:
       }
     } else {
       if (!F->getChildren<Feature>().empty()) {
-        // TODO handle this
+        // TODO (se-passau/VaRA#744): error, non recursive 0remove on non leaf
+        // feature
         return;
       }
       if (!F->getChildren<Relationship>().empty()) {

--- a/include/vara/Feature/FeatureModelTransaction.h
+++ b/include/vara/Feature/FeatureModelTransaction.h
@@ -24,10 +24,10 @@ using ConsistencyCheck =
     FeatureModelConsistencyChecker<ExactlyOneRootNode,
                                    EveryFeatureRequiresParent,
                                    CheckFeatureParentChildRelationShip>;
-} // namespace detail
 
-using FeatureVariant = std::variant<std::string, Feature *>;
-using FeatureTreeNodeVariant = std::variant<std::string, FeatureTreeNode *>;
+using FeatureVariantTy = std::variant<std::string, Feature *>;
+using FeatureTreeNodeVariantTy = std::variant<std::string, FeatureTreeNode *>;
+} // namespace detail
 
 template <typename CopyMode>
 class FeatureModelTransaction
@@ -100,7 +100,7 @@ public:
   }
 
   decltype(auto) addRelationship(Relationship::RelationshipKind Kind,
-                                 const FeatureVariant &Parent) {
+                                 const detail::FeatureVariantTy &Parent) {
     if constexpr (IsCopyMode) {
       return this->addRelationshipImpl(Kind, Parent);
     } else {
@@ -108,7 +108,8 @@ public:
     }
   }
 
-  decltype(auto) addLocation(const FeatureVariant &F, FeatureSourceRange FSR) {
+  decltype(auto) addLocation(const detail::FeatureVariantTy &F,
+                             FeatureSourceRange FSR) {
     if constexpr (IsCopyMode) {
       return this->addLocationImpl(F, FSR);
     } else {
@@ -140,8 +141,8 @@ public:
     }
   }
 
-  decltype(auto) addChild(const FeatureTreeNodeVariant &Parent,
-                          const FeatureTreeNodeVariant &Child) {
+  decltype(auto) addChild(const detail::FeatureTreeNodeVariantTy &Parent,
+                          const detail::FeatureTreeNodeVariantTy &Child) {
     if constexpr (IsCopyMode) {
       return this->addChildImpl(Parent, Child);
     } else {
@@ -340,11 +341,11 @@ public:
 
 private:
   AddRelationshipToModel(Relationship::RelationshipKind Kind,
-                         FeatureVariant Parent)
+                         FeatureVariantTy Parent)
       : Kind(Kind), Parent(std::move(Parent)) {}
 
   Relationship::RelationshipKind Kind;
-  FeatureVariant Parent;
+  FeatureVariantTy Parent;
 };
 
 //===----------------------------------------------------------------------===//
@@ -369,10 +370,10 @@ public:
   }
 
 private:
-  AddLocationToFeature(FeatureVariant F, FeatureSourceRange FSR)
+  AddLocationToFeature(FeatureVariantTy F, FeatureSourceRange FSR)
       : F(std::move(F)), FSR(std::move(FSR)) {}
 
-  FeatureVariant F;
+  FeatureVariantTy F;
   FeatureSourceRange FSR;
 };
 
@@ -542,11 +543,11 @@ public:
   }
 
 private:
-  AddChild(FeatureTreeNodeVariant Parent, FeatureTreeNodeVariant Child)
+  AddChild(FeatureTreeNodeVariantTy Parent, FeatureTreeNodeVariantTy Child)
       : Child(std::move(Child)), Parent(std::move(Parent)) {}
 
-  FeatureTreeNodeVariant Child;
-  FeatureTreeNodeVariant Parent;
+  FeatureTreeNodeVariantTy Child;
+  FeatureTreeNodeVariantTy Parent;
 };
 
 class FeatureModelCopyTransactionBase {
@@ -585,7 +586,7 @@ protected:
   }
 
   Relationship *addRelationshipImpl(Relationship::RelationshipKind Kind,
-                                    const FeatureVariant &Parent) {
+                                    const FeatureVariantTy &Parent) {
     if (!FM) {
       return nullptr;
     }
@@ -600,7 +601,7 @@ protected:
                                            Parent)))(*FM);
   }
 
-  void addLocationImpl(const FeatureVariant &F, FeatureSourceRange FSR) {
+  void addLocationImpl(const FeatureVariantTy &F, FeatureSourceRange FSR) {
     assert(FM && "");
 
     FeatureModelModification::make_modification<AddLocationToFeature>(
@@ -644,8 +645,8 @@ protected:
         std::move(Root))(*FM);
   }
 
-  static void addChildImpl(const FeatureTreeNodeVariant &Parent,
-                           const FeatureTreeNodeVariant &Child) {
+  static void addChildImpl(const FeatureTreeNodeVariantTy &Parent,
+                           const FeatureTreeNodeVariantTy &Child) {
     FeatureModelModification::make_modification<AddChild>(Parent, Child);
   }
 
@@ -694,12 +695,12 @@ protected:
   }
 
   void addRelationshipImpl(Relationship::RelationshipKind Kind,
-                           const FeatureVariant &Parent) {
+                           const FeatureVariantTy &Parent) {
     Modifications.push_back(FeatureModelModification::make_unique_modification<
                             AddRelationshipToModel>(Kind, Parent));
   }
 
-  void addLocationImpl(const FeatureVariant &F, FeatureSourceRange FSR) {
+  void addLocationImpl(const FeatureVariantTy &F, FeatureSourceRange FSR) {
     Modifications.push_back(FeatureModelModification::make_unique_modification<
                             AddLocationToFeature>(F, std::move(FSR)));
   }
@@ -741,8 +742,8 @@ protected:
             std::move(Root)));
   }
 
-  void addChildImpl(const FeatureTreeNodeVariant &Parent,
-                    const FeatureTreeNodeVariant &Child) {
+  void addChildImpl(const FeatureTreeNodeVariantTy &Parent,
+                    const FeatureTreeNodeVariantTy &Child) {
     assert(FM && "");
 
     Modifications.push_back(

--- a/include/vara/Feature/FeatureSourceRange.h
+++ b/include/vara/Feature/FeatureSourceRange.h
@@ -73,6 +73,13 @@ public:
                      Category CategoryKind = Category::necessary)
       : Path(std::move(Path)), Start(std::move(Start)), End(std::move(End)),
         CategoryKind(CategoryKind) {}
+
+  FeatureSourceRange(fs::path Path, FeatureSourceLocation Start,
+                     FeatureSourceLocation End,
+                     Category CategoryKind = Category::necessary)
+      : FeatureSourceRange(std::move(Path), std::optional(std::move(Start)),
+                           std::optional(std::move(End)), CategoryKind) {}
+
   FeatureSourceRange(const FeatureSourceRange &L) = default;
   FeatureSourceRange &operator=(const FeatureSourceRange &) = default;
   FeatureSourceRange(FeatureSourceRange &&) = default;

--- a/include/vara/Feature/OrderedFeatureVector.h
+++ b/include/vara/Feature/OrderedFeatureVector.h
@@ -3,6 +3,8 @@
 
 #include "vara/Feature/Feature.h"
 
+#include <algorithm>
+
 namespace vara::feature {
 
 //===----------------------------------------------------------------------===//
@@ -55,6 +57,13 @@ public:
 
   void insert(std::initializer_list<Feature *> Init) {
     insert(Init.begin(), Init.end());
+  }
+
+  void sort() {
+    std::sort(Features.begin(), Features.end(),
+              [](vara::feature::Feature *A, vara::feature::Feature *B) {
+                return *A < *B;
+              });
   }
 
   [[nodiscard]] unsigned int size() { return Features.size(); }

--- a/include/vara/Feature/OrderedFeatureVector.h
+++ b/include/vara/Feature/OrderedFeatureVector.h
@@ -5,7 +5,7 @@
 
 #include <algorithm>
 
-namespace vara::feature {
+namespace vara::feature::deprecated {
 
 //===----------------------------------------------------------------------===//
 //                            OrderedFeatureVector Class
@@ -59,13 +59,6 @@ public:
     insert(Init.begin(), Init.end());
   }
 
-  void sort() {
-    std::sort(Features.begin(), Features.end(),
-              [](vara::feature::Feature *A, vara::feature::Feature *B) {
-                return *A < *B;
-              });
-  }
-
   [[nodiscard]] unsigned int size() { return Features.size(); }
 
   [[nodiscard]] bool empty() { return Features.empty(); }
@@ -83,6 +76,7 @@ public:
 private:
   llvm::SmallVector<Feature *, 5> Features;
 };
-} // namespace vara::feature
+
+} // namespace vara::feature::deprecated
 
 #endif // VARA_FEATURE_ORDEREDFEATUREVECTOR_H

--- a/lib/Feature/CMakeLists.txt
+++ b/lib/Feature/CMakeLists.txt
@@ -2,6 +2,7 @@ set(FEATURE_LIB_SRC
   Constraint.cpp
   Feature.cpp
   FeatureModel.cpp
+  FeatureModelBuilder.cpp
   FeatureModelParser.cpp
   FeatureModelTransaction.cpp
   FeatureModelWriter.cpp

--- a/lib/Feature/FeatureModel.cpp
+++ b/lib/Feature/FeatureModel.cpp
@@ -48,7 +48,6 @@ std::unique_ptr<FeatureModel> FeatureModel::clone() {
   FMB.setVmName(this->getName().str());
   FMB.setCommit(this->getCommit().str());
   FMB.setPath(this->getPath().string());
-  FMB.setRoot(this->getRoot()->getName().str());
 
   for (const auto &KV : this->Features) {
     // TODO(s9latimm): Add unittests for cloned FeatureSourceRanges
@@ -61,7 +60,7 @@ std::unique_ptr<FeatureModel> FeatureModel::clone() {
       FMB.makeFeature<Feature>(KV.getValue()->getName().str());
       break;
     case Feature::FeatureKind::FK_ROOT:
-      FMB.makeFeature<RootFeature>(KV.getValue()->getName().str());
+      FMB.makeRoot(KV.getValue()->getName().str());
       break;
     case Feature::FeatureKind::FK_BINARY:
       if (auto *F = llvm::dyn_cast<BinaryFeature>(KV.getValue().get()); F) {

--- a/lib/Feature/FeatureModel.cpp
+++ b/lib/Feature/FeatureModel.cpp
@@ -31,12 +31,6 @@ Feature *FeatureModel::addFeature(std::unique_ptr<Feature> NewFeature) {
   return InsertedFeature;
 }
 
-Relationship *
-FeatureModel::addRelationship(std::unique_ptr<RelationshipTy> Relationship) {
-  Relationships.push_back(std::move(Relationship));
-  return Relationships.back().get();
-}
-
 void FeatureModel::removeFeature(Feature &F) {
   if (&F == Root) {
     Root = nullptr;

--- a/lib/Feature/FeatureModel.cpp
+++ b/lib/Feature/FeatureModel.cpp
@@ -39,14 +39,8 @@ void FeatureModel::removeFeature(Feature &F) {
   Features.erase(F.getName());
 }
 
-RootFeature *FeatureModel::setRoot(std::unique_ptr<RootFeature> NewRoot) {
-  auto PosRootFeature =
-      Features.try_emplace(std::string(NewRoot->getName()), std::move(NewRoot));
-  if (!PosRootFeature.second) {
-    return nullptr;
-  }
-  return Root = llvm::dyn_cast<RootFeature>(
-             PosRootFeature.first->getValue().get());
+RootFeature *FeatureModel::setRoot(RootFeature &NewRoot) {
+  return Root = &NewRoot;
 }
 
 std::unique_ptr<FeatureModel> FeatureModel::clone() {

--- a/lib/Feature/FeatureModel.cpp
+++ b/lib/Feature/FeatureModel.cpp
@@ -84,16 +84,9 @@ std::unique_ptr<FeatureModel> FeatureModel::clone() {
   }
 
   for (const auto &Rel : this->Relationships) {
-    std::vector<std::string> FeatureNames;
-    for (auto *Child : Rel->children()) {
-      if (auto *ChildFeature = llvm::dyn_cast<Feature>(Child)) {
-        FeatureNames.emplace_back(ChildFeature->getName());
-      }
-    }
-    if (auto *ParentFeature = llvm::dyn_cast<Feature>(Rel->getParent())) {
-      FMB.emplaceRelationship(Rel->getKind(), FeatureNames,
-                              ParentFeature->getName().str());
-    }
+    FMB.emplaceRelationship(
+        Rel->getKind(),
+        llvm::dyn_cast<Feature>(Rel->getParent())->getName().str());
   }
 
   // We can use recursive cloning on constraints, as we can rely on the

--- a/lib/Feature/FeatureModel.cpp
+++ b/lib/Feature/FeatureModel.cpp
@@ -25,17 +25,13 @@ Feature *FeatureModel::addFeature(std::unique_ptr<Feature> NewFeature) {
   if (!PosInsertedFeature.second) {
     return nullptr;
   }
-  auto *InsertedFeature = PosInsertedFeature.first->getValue().get();
-  assert(InsertedFeature);
-  OrderedFeatures.insert(InsertedFeature);
-  return InsertedFeature;
+  return PosInsertedFeature.first->getValue().get();
 }
 
 void FeatureModel::removeFeature(Feature &F) {
   if (&F == Root) {
     Root = nullptr;
   }
-  OrderedFeatures.remove(&F);
   Features.erase(F.getName());
 }
 

--- a/lib/Feature/FeatureModel.cpp
+++ b/lib/Feature/FeatureModel.cpp
@@ -84,9 +84,9 @@ std::unique_ptr<FeatureModel> FeatureModel::clone() {
   }
 
   for (const auto &Rel : this->Relationships) {
-    FMB.emplaceRelationship(
-        Rel->getKind(),
-        llvm::dyn_cast<Feature>(Rel->getParent())->getName().str());
+    if (auto *P = llvm::dyn_cast_or_null<Feature>(Rel->getParent())) {
+      FMB.emplaceRelationship(Rel->getKind(), P->getName().str());
+    }
   }
 
   // We can use recursive cloning on constraints, as we can rely on the

--- a/lib/Feature/FeatureModel.cpp
+++ b/lib/Feature/FeatureModel.cpp
@@ -46,7 +46,6 @@ std::unique_ptr<FeatureModel> FeatureModel::clone() {
   FMB.setPath(this->getPath().string());
 
   for (const auto &KV : this->Features) {
-    // TODO(s9latimm): Add unittests for cloned FeatureSourceRanges
     std::vector<FeatureSourceRange> SourceRanges(
         KV.getValue()->getLocations().begin(),
         KV.getValue()->getLocations().end());

--- a/lib/Feature/FeatureModel.cpp
+++ b/lib/Feature/FeatureModel.cpp
@@ -26,6 +26,12 @@ Feature *FeatureModel::addFeature(std::unique_ptr<Feature> NewFeature) {
   return InsertedFeature;
 }
 
+Relationship *
+FeatureModel::addRelationship(std::unique_ptr<RelationshipTy> Relationship) {
+  Relationships.push_back(std::move(Relationship));
+  return Relationships.back().get();
+}
+
 void FeatureModel::removeFeature(Feature &F) {
   if (&F == Root) {
     Root = nullptr;

--- a/lib/Feature/FeatureModel.cpp
+++ b/lib/Feature/FeatureModel.cpp
@@ -1,8 +1,13 @@
 #include "vara/Feature/FeatureModel.h"
+#include "vara/Feature/FeatureModelBuilder.h"
 
 #include "llvm/Support/Casting.h"
 
 #include <algorithm>
+
+//===----------------------------------------------------------------------===//
+//                          FeatureModel
+//===----------------------------------------------------------------------===//
 
 namespace vara::feature {
 void FeatureModel::dump() const {
@@ -34,12 +39,22 @@ void FeatureModel::removeFeature(Feature &F) {
   Features.erase(F.getName());
 }
 
+RootFeature *FeatureModel::setRoot(std::unique_ptr<RootFeature> NewRoot) {
+  auto PosRootFeature =
+      Features.try_emplace(std::string(NewRoot->getName()), std::move(NewRoot));
+  if (!PosRootFeature.second) {
+    return nullptr;
+  }
+  return Root = llvm::dyn_cast<RootFeature>(
+             PosRootFeature.first->getValue().get());
+}
+
 std::unique_ptr<FeatureModel> FeatureModel::clone() {
   FeatureModelBuilder FMB;
   FMB.setVmName(this->getName().str());
   FMB.setCommit(this->getCommit().str());
   FMB.setPath(this->getPath().string());
-  FMB.setRootName(this->getRoot()->getName().str());
+  FMB.setRoot(this->getRoot()->getName().str());
 
   for (const auto &KV : this->Features) {
     // TODO(s9latimm): Add unittests for cloned FeatureSourceRanges
@@ -97,208 +112,6 @@ std::unique_ptr<FeatureModel> FeatureModel::clone() {
   }
 
   return FMB.buildFeatureModel();
-}
-
-/// Decide whether two features are mutual exclusive. Beware that this method
-/// only detects very simple trees with binary excludes.
-bool isSimpleMutex(const Feature *A, const Feature *B) {
-  return std::any_of(
-      A->excludes().begin(), A->excludes().end(), [A, B](const auto *E) {
-        if (const auto *LHS =
-                llvm::dyn_cast<PrimaryFeatureConstraint>(E->getLeftOperand());
-            LHS) {
-          if (const auto *RHS = llvm::dyn_cast<PrimaryFeatureConstraint>(
-                  E->getRightOperand());
-              RHS) {
-            // A excludes B
-            if (LHS->getFeature() &&
-                LHS->getFeature()->getName() == A->getName() &&
-                RHS->getFeature() &&
-                RHS->getFeature()->getName() == B->getName()) {
-              return std::any_of(
-                  B->excludes().begin(), B->excludes().end(),
-                  [A, B](const auto *E) {
-                    if (const auto *LHS =
-                            llvm::dyn_cast<PrimaryFeatureConstraint>(
-                                E->getLeftOperand());
-                        LHS) {
-                      if (const auto *RHS =
-                              llvm::dyn_cast<PrimaryFeatureConstraint>(
-                                  E->getRightOperand());
-                          RHS) {
-                        // B excludes A
-                        return LHS->getFeature() &&
-                               LHS->getFeature()->getName() == B->getName() &&
-                               RHS->getFeature() &&
-                               RHS->getFeature()->getName() == A->getName();
-                      }
-                    }
-                    return false;
-                  });
-            }
-          }
-        }
-        return false;
-      });
-}
-
-/// Collect mutual exclusive feature constraints for clean up.
-llvm::SmallSet<Constraint *, 3>
-cleanUpMutualExclusiveConstraints(const Feature *A,
-                                  const llvm::SmallSet<Feature *, 3> &Xor) {
-  llvm::SmallSet<Constraint *, 3> Remove;
-  for (const auto *E : A->excludes()) {
-    if (auto *LHS =
-            llvm::dyn_cast<PrimaryFeatureConstraint>(E->getLeftOperand());
-        LHS) {
-      if (auto *RHS =
-              llvm::dyn_cast<PrimaryFeatureConstraint>(E->getRightOperand());
-          RHS) {
-        if (LHS->getFeature() && LHS->getFeature()->getName() == A->getName() &&
-            RHS->getFeature() && Xor.count(RHS->getFeature())) {
-          Remove.insert(LHS);
-        } else if (LHS->getFeature() && Xor.count(LHS->getFeature()) &&
-                   RHS->getFeature() &&
-                   RHS->getFeature()->getName() == A->getName()) {
-          Remove.insert(RHS);
-        }
-      }
-    }
-  }
-  return Remove;
-}
-
-void FeatureModelBuilder::detectXMLAlternatives() {
-  for (const auto &FeatureName : Features.keys()) {
-    std::vector<std::string> Frontier(Children[FeatureName].begin(),
-                                      Children[FeatureName].end());
-    while (!Frontier.empty()) {
-      const std::string FName{Frontier.back()};
-      Frontier.pop_back();
-      if (auto *F = llvm::dyn_cast<Feature>(Features[FName].get());
-          F && !F->isOptional()) {
-        llvm::SmallSet<Feature *, 3> Xor;
-        Xor.insert(F);
-        for (const auto &Name : Frontier) {
-          if (auto *E = llvm::dyn_cast<Feature>(Features[Name].get());
-              E && !E->isOptional()) {
-            if (std::all_of(Xor.begin(), Xor.end(), [E](const auto *F) {
-                  return isSimpleMutex(F, E);
-                })) {
-              Xor.insert(E);
-            }
-          }
-        }
-        if (Xor.size() > 1) {
-          std::vector<std::string> V;
-          for (auto *E : Xor) {
-            Frontier.erase(std::remove(Frontier.begin(), Frontier.end(),
-                                       E->getName().str()),
-                           Frontier.end());
-            V.push_back(E->getName().str());
-            for (auto *R : cleanUpMutualExclusiveConstraints(E, Xor)) {
-              E->removeConstraintNonPreserve(R);
-            }
-          }
-          emplaceRelationship(Relationship::RelationshipKind::RK_ALTERNATIVE, V,
-                              FeatureName.str());
-        }
-      }
-    }
-  }
-}
-
-bool FeatureModelBuilder::buildConstraints() {
-  auto B = BuilderVisitor(this);
-  for (const auto &C : Constraints) {
-    C->accept(B);
-  }
-  detectXMLAlternatives();
-  return true;
-}
-
-bool FeatureModelBuilder::buildTree(const string &FeatureName,
-                                    std::set<std::string> &Visited) {
-  if (find(Visited.begin(), Visited.end(), FeatureName) != Visited.end()) {
-    llvm::errs() << "error: Cycle or duplicate edge in \'" << FeatureName
-                 << "\'.\n";
-    return false;
-  }
-  Visited.insert(FeatureName);
-
-  if (find(Features.keys().begin(), Features.keys().end(), FeatureName) ==
-      Features.keys().end()) {
-    llvm::errs() << "error: Missing feature \'\'" << FeatureName << "\'.\n";
-    return false;
-  }
-
-  for (const auto &Child : Children[FeatureName]) {
-    if (Parents[Child] != FeatureName) {
-      llvm::errs() << "error: Parent of \'" << Child << "\' does not match \'"
-                   << FeatureName << "\'.\n";
-      return false;
-    }
-    if (!buildTree(Child, Visited)) {
-      return false;
-    }
-  }
-
-  llvm::SmallSet<std::string, 3> Skip;
-  if (RelationshipEdges.find(FeatureName) != RelationshipEdges.end()) {
-    for (const auto &Pair : RelationshipEdges[FeatureName]) {
-      auto R = std::make_unique<Relationship>(Pair.first);
-      Features[FeatureName]->addEdge(R.get());
-      R->setParent(Features[FeatureName].get());
-      for (const auto &Child : Pair.second) {
-        if (Children[FeatureName].count(Child) == 0) {
-          llvm::errs() << "error: Related node \'" << Child
-                       << "\' is not child of \'" << FeatureName << "\'.\n";
-          return false;
-        }
-        Skip.insert(Child);
-        R->addEdge(Features[Child].get());
-        Features[Child]->setParent(R.get());
-      }
-      Relationships.push_back(std::move(R));
-    }
-  }
-  for (const auto &Child : Children[FeatureName]) {
-    if (Skip.count(Child) > 0) {
-      continue;
-    }
-    Features[FeatureName]->addEdge(Features[Child].get());
-    Features[Child]->setParent(Features[FeatureName].get());
-  }
-  return true;
-}
-
-bool FeatureModelBuilder::buildRoot() {
-  Root = Features.find(RootName) != Features.end()
-             ? Features[RootName].get()
-             : makeFeature<RootFeature>(RootName);
-  if (!llvm::isa_and_nonnull<RootFeature>(Root)) {
-    llvm::errs() << "error: Missing root node.\n";
-    return false;
-  }
-
-  for (const auto &FeatureName : Features.keys()) {
-    if (FeatureName != Root->getName() &&
-        Parents.find(FeatureName) == Parents.end()) {
-      Children[RootName].insert(std::string(FeatureName));
-      Parents[FeatureName] = RootName;
-    }
-  }
-  return true;
-}
-
-std::unique_ptr<FeatureModel> FeatureModelBuilder::buildFeatureModel() {
-  std::set<std::string> Visited;
-  if (!buildRoot() || !buildConstraints() || !buildTree(RootName, Visited)) {
-    return nullptr;
-  }
-  return std::make_unique<FeatureModel>(Name, Path, Commit, std::move(Features),
-                                        std::move(Constraints),
-                                        std::move(Relationships), Root);
 }
 
 } // namespace vara::feature

--- a/lib/Feature/FeatureModelBuilder.cpp
+++ b/lib/Feature/FeatureModelBuilder.cpp
@@ -1,0 +1,205 @@
+#include "vara/Feature/FeatureModelBuilder.h"
+
+namespace vara::feature {
+
+//===----------------------------------------------------------------------===//
+//                        FeatureModelBuilder
+//===----------------------------------------------------------------------===//
+
+/// Decide whether two features are mutual exclusive. Beware that this method
+/// only detects very simple trees with binary excludes.
+bool isSimpleMutex(const Feature *A, const Feature *B) {
+  return std::any_of(
+      A->excludes().begin(), A->excludes().end(), [A, B](const auto *E) {
+        if (const auto *LHS =
+                llvm::dyn_cast<PrimaryFeatureConstraint>(E->getLeftOperand());
+            LHS) {
+          if (const auto *RHS = llvm::dyn_cast<PrimaryFeatureConstraint>(
+                  E->getRightOperand());
+              RHS) {
+            // A excludes B
+            if (LHS->getFeature() &&
+                LHS->getFeature()->getName() == A->getName() &&
+                RHS->getFeature() &&
+                RHS->getFeature()->getName() == B->getName()) {
+              return std::any_of(
+                  B->excludes().begin(), B->excludes().end(),
+                  [A, B](const auto *E) {
+                    if (const auto *LHS =
+                            llvm::dyn_cast<PrimaryFeatureConstraint>(
+                                E->getLeftOperand());
+                        LHS) {
+                      if (const auto *RHS =
+                              llvm::dyn_cast<PrimaryFeatureConstraint>(
+                                  E->getRightOperand());
+                          RHS) {
+                        // B excludes A
+                        return LHS->getFeature() &&
+                               LHS->getFeature()->getName() == B->getName() &&
+                               RHS->getFeature() &&
+                               RHS->getFeature()->getName() == A->getName();
+                      }
+                    }
+                    return false;
+                  });
+            }
+          }
+        }
+        return false;
+      });
+}
+
+/// Collect mutual exclusive feature constraints for clean up.
+llvm::SmallSet<Constraint *, 3>
+cleanUpMutualExclusiveConstraints(const Feature *A,
+                                  const llvm::SmallSet<Feature *, 3> &Xor) {
+  llvm::SmallSet<Constraint *, 3> Remove;
+  for (const auto *E : A->excludes()) {
+    if (auto *LHS =
+            llvm::dyn_cast<PrimaryFeatureConstraint>(E->getLeftOperand());
+        LHS) {
+      if (auto *RHS =
+              llvm::dyn_cast<PrimaryFeatureConstraint>(E->getRightOperand());
+          RHS) {
+        if (LHS->getFeature() && LHS->getFeature()->getName() == A->getName() &&
+            RHS->getFeature() && Xor.count(RHS->getFeature())) {
+          Remove.insert(LHS);
+        } else if (LHS->getFeature() && Xor.count(LHS->getFeature()) &&
+                   RHS->getFeature() &&
+                   RHS->getFeature()->getName() == A->getName()) {
+          Remove.insert(RHS);
+        }
+      }
+    }
+  }
+  return Remove;
+}
+
+void FeatureModelBuilder::detectXMLAlternatives() {
+  for (const auto &FeatureName : Features.keys()) {
+    std::vector<std::string> Frontier(Children[FeatureName].begin(),
+                                      Children[FeatureName].end());
+    while (!Frontier.empty()) {
+      const std::string FName{Frontier.back()};
+      Frontier.pop_back();
+      if (auto *F = llvm::dyn_cast<Feature>(Features[FName].get());
+          F && !F->isOptional()) {
+        llvm::SmallSet<Feature *, 3> Xor;
+        Xor.insert(F);
+        for (const auto &Name : Frontier) {
+          if (auto *E = llvm::dyn_cast<Feature>(Features[Name].get());
+              E && !E->isOptional()) {
+            if (std::all_of(Xor.begin(), Xor.end(), [E](const auto *F) {
+                  return isSimpleMutex(F, E);
+                })) {
+              Xor.insert(E);
+            }
+          }
+        }
+        if (Xor.size() > 1) {
+          std::vector<std::string> V;
+          for (auto *E : Xor) {
+            Frontier.erase(std::remove(Frontier.begin(), Frontier.end(),
+                                       E->getName().str()),
+                           Frontier.end());
+            V.push_back(E->getName().str());
+            for (auto *R : cleanUpMutualExclusiveConstraints(E, Xor)) {
+              E->removeConstraintNonPreserve(R);
+            }
+          }
+          emplaceRelationship(Relationship::RelationshipKind::RK_ALTERNATIVE, V,
+                              FeatureName.str());
+        }
+      }
+    }
+  }
+}
+
+bool FeatureModelBuilder::buildConstraints() {
+  auto B = BuilderVisitor(this);
+  for (const auto &C : Constraints) {
+    C->accept(B);
+  }
+  detectXMLAlternatives();
+  return true;
+}
+
+bool FeatureModelBuilder::buildTree(const string &FeatureName,
+                                    std::set<std::string> &Visited) {
+  if (find(Visited.begin(), Visited.end(), FeatureName) != Visited.end()) {
+    llvm::errs() << "error: Cycle or duplicate edge in \'" << FeatureName
+                 << "\'.\n";
+    return false;
+  }
+  Visited.insert(FeatureName);
+
+  if (find(Features.keys().begin(), Features.keys().end(), FeatureName) ==
+      Features.keys().end()) {
+    llvm::errs() << "error: Missing feature \'\'" << FeatureName << "\'.\n";
+    return false;
+  }
+
+  for (const auto &Child : Children[FeatureName]) {
+    if (Parents[Child] != FeatureName) {
+      llvm::errs() << "error: Parent of \'" << Child << "\' does not match \'"
+                   << FeatureName << "\'.\n";
+      return false;
+    }
+    if (!buildTree(Child, Visited)) {
+      return false;
+    }
+  }
+
+  llvm::SmallSet<std::string, 3> Skip;
+  if (RelationshipEdges.find(FeatureName) != RelationshipEdges.end()) {
+    for (const auto &Pair : RelationshipEdges[FeatureName]) {
+      auto R = std::make_unique<Relationship>(Pair.first);
+      Features[FeatureName]->addEdge(R.get());
+      R->setParent(Features[FeatureName].get());
+      for (const auto &Child : Pair.second) {
+        if (Children[FeatureName].count(Child) == 0) {
+          llvm::errs() << "error: Related node \'" << Child
+                       << "\' is not child of \'" << FeatureName << "\'.\n";
+          return false;
+        }
+        Skip.insert(Child);
+        R->addEdge(Features[Child].get());
+        Features[Child]->setParent(R.get());
+      }
+      Relationships.push_back(std::move(R));
+    }
+  }
+
+  for (const auto &Child : Children[FeatureName]) {
+    if (Skip.count(Child) > 0) {
+      continue;
+    }
+    Features[FeatureName]->addEdge(Features[Child].get());
+    Features[Child]->setParent(Features[FeatureName].get());
+  }
+  return true;
+}
+
+bool FeatureModelBuilder::buildRoot() {
+  assert(Root);
+  for (const auto &FeatureName : Features.keys()) {
+    if (FeatureName != Root->getName() &&
+        Parents.find(FeatureName) == Parents.end()) {
+      Children[RootName].insert(std::string(FeatureName));
+      Parents[FeatureName] = RootName;
+    }
+  }
+  return true;
+}
+
+std::unique_ptr<FeatureModel> FeatureModelBuilder::buildFeatureModel() {
+  std::set<std::string> Visited;
+  if (!buildRoot() || !buildConstraints() || !buildTree(RootName, Visited)) {
+    return nullptr;
+  }
+  return std::make_unique<FeatureModel>(Name, Path, Commit, std::move(Features),
+                                        std::move(Constraints),
+                                        std::move(Relationships), Root);
+}
+
+} // namespace vara::feature

--- a/lib/Feature/FeatureModelBuilder.cpp
+++ b/lib/Feature/FeatureModelBuilder.cpp
@@ -6,43 +6,6 @@ namespace vara::feature {
 //                        FeatureModelBuilder
 //===----------------------------------------------------------------------===//
 
-/// Decide whether feature A excludes B. Beware that this method only detects
-/// very simple trees with binary excludes.
-bool detectExclude(const Feature *A, const Feature *B) {
-  return std::any_of(
-      A->excludes().begin(), A->excludes().end(), [A, B](const auto *E) {
-        if (const auto *LHS =
-                llvm::dyn_cast<PrimaryFeatureConstraint>(E->getLeftOperand())) {
-          if (const auto *RHS = llvm::dyn_cast<PrimaryFeatureConstraint>(
-                  E->getRightOperand())) {
-            return (LHS->getFeature() &&
-                    LHS->getFeature()->getName() == A->getName() &&
-                    RHS->getFeature() &&
-                    RHS->getFeature()->getName() == B->getName());
-          }
-        }
-        return false;
-      });
-}
-
-bool FeatureModelBuilder::detectXMLAlternatives() {
-  for (auto *F : FM->features()) {
-    auto Children = F->getChildren<Feature>();
-    if (Children.size() > 1 &&
-        std::all_of(Children.begin(), Children.end(), [Children](auto *F) {
-          return !F->isOptional() &&
-                 std::all_of(Children.begin(), Children.end(), [F](auto *C) {
-                   return F == C ||
-                          (detectExclude(F, C) && detectExclude(C, F));
-                 });
-        })) {
-      Special.addRelationship(Relationship::RelationshipKind::RK_ALTERNATIVE,
-                              F);
-    }
-  }
-  return true;
-}
-
 std::unique_ptr<FeatureModel> FeatureModelBuilder::buildFeatureModel() {
   if (!FM->getRoot()) {
     auto T = FeatureModelModifyTransaction::openTransaction(*FM);
@@ -51,9 +14,7 @@ std::unique_ptr<FeatureModel> FeatureModelBuilder::buildFeatureModel() {
       return nullptr;
     }
   }
-  return Features.commit() && Transactions.commit() &&
-                 PostTransactions.commit() && detectXMLAlternatives() &&
-                 Special.commit()
+  return Features.commit() && Transactions.commit() && PostTransactions.commit()
              ? std::move(FM)
              : nullptr;
 }

--- a/lib/Feature/FeatureModelBuilder.cpp
+++ b/lib/Feature/FeatureModelBuilder.cpp
@@ -49,68 +49,23 @@ bool isSimpleMutex(const Feature *A, const Feature *B) {
       });
 }
 
-/// Collect mutual exclusive feature constraints for clean up.
-llvm::SmallSet<Constraint *, 3>
-cleanUpMutualExclusiveConstraints(const Feature *A,
-                                  const llvm::SmallSet<Feature *, 3> &Xor) {
-  llvm::SmallSet<Constraint *, 3> Remove;
-  for (const auto *E : A->excludes()) {
-    if (auto *LHS =
-            llvm::dyn_cast<PrimaryFeatureConstraint>(E->getLeftOperand());
-        LHS) {
-      if (auto *RHS =
-              llvm::dyn_cast<PrimaryFeatureConstraint>(E->getRightOperand());
-          RHS) {
-        if (LHS->getFeature() && LHS->getFeature()->getName() == A->getName() &&
-            RHS->getFeature() && Xor.count(RHS->getFeature())) {
-          Remove.insert(LHS);
-        } else if (LHS->getFeature() && Xor.count(LHS->getFeature()) &&
-                   RHS->getFeature() &&
-                   RHS->getFeature()->getName() == A->getName()) {
-          Remove.insert(RHS);
-        }
-      }
-    }
-  }
-  return Remove;
-}
-
 bool FeatureModelBuilder::detectXMLAlternatives() {
-  for (auto *Node : FM->features()) {
-    std::vector<FeatureTreeNode *> Frontier;
-    std::copy_if(Node->begin(), Node->end(), std::back_inserter(Frontier),
-                 [](auto *N) { return llvm::isa<Feature>(N); });
-    while (!Frontier.empty()) {
-      auto *B = Frontier.back();
-      Frontier.pop_back();
-      if (auto *F = llvm::dyn_cast<Feature>(B); F && !F->isOptional()) {
-        llvm::SmallSet<Feature *, 3> Xor;
-        Xor.insert(F);
-        for (auto *FF : Frontier) {
-          if (auto *E = llvm::dyn_cast<Feature>(FF); E && !E->isOptional()) {
-            if (std::all_of(Xor.begin(), Xor.end(), [E](const auto *F) {
-                  return isSimpleMutex(F, E);
-                })) {
-              Xor.insert(E);
+  for (auto *F : FM->features()) {
+    auto Children = F->getChildren<Feature>();
+    if (Children.size() > 1 &&
+        std::all_of(Children.begin(), Children.end(), [Children](auto *F) {
+          for (auto *C : Children) {
+            if (F == C) {
+              continue;
+            }
+            if (!isSimpleMutex(F, C)) {
+              return false;
             }
           }
-        }
-        if (Xor.size() > 1) {
-          for (auto *E : Xor) {
-            Frontier.erase(std::remove(Frontier.begin(), Frontier.end(), E),
-                           Frontier.end());
-            // TODO
-            //            for (auto *R : cleanUpMutualExclusiveConstraints(E,
-            //            Xor)) {
-            //              E->removeConstraintNonPreserve(R);
-            //            }
-          }
-          // TODO
-          //          Special.addRelationship(
-          //              Relationship::RelationshipKind::RK_ALTERNATIVE, F,
-          //              std::set(Xor.begin(), Xor.end()));
-        }
-      }
+          return !F->isOptional();
+        })) {
+      Special.addRelationship(Relationship::RelationshipKind::RK_ALTERNATIVE,
+                              F);
     }
   }
   return true;

--- a/lib/Feature/FeatureModelBuilder.cpp
+++ b/lib/Feature/FeatureModelBuilder.cpp
@@ -76,47 +76,48 @@ cleanUpMutualExclusiveConstraints(const Feature *A,
 }
 
 void FeatureModelBuilder::detectXMLAlternatives() {
-  for (const auto &FeatureName : Features.keys()) {
-    std::vector<std::string> Frontier(Children[FeatureName].begin(),
-                                      Children[FeatureName].end());
-    while (!Frontier.empty()) {
-      const std::string FName{Frontier.back()};
-      Frontier.pop_back();
-      if (auto *F = llvm::dyn_cast<Feature>(Features[FName].get());
-          F && !F->isOptional()) {
-        llvm::SmallSet<Feature *, 3> Xor;
-        Xor.insert(F);
-        for (const auto &Name : Frontier) {
-          if (auto *E = llvm::dyn_cast<Feature>(Features[Name].get());
-              E && !E->isOptional()) {
-            if (std::all_of(Xor.begin(), Xor.end(), [E](const auto *F) {
-                  return isSimpleMutex(F, E);
-                })) {
-              Xor.insert(E);
-            }
-          }
-        }
-        if (Xor.size() > 1) {
-          std::vector<std::string> V;
-          for (auto *E : Xor) {
-            Frontier.erase(std::remove(Frontier.begin(), Frontier.end(),
-                                       E->getName().str()),
-                           Frontier.end());
-            V.push_back(E->getName().str());
-            for (auto *R : cleanUpMutualExclusiveConstraints(E, Xor)) {
-              E->removeConstraintNonPreserve(R);
-            }
-          }
-          emplaceRelationship(Relationship::RelationshipKind::RK_ALTERNATIVE, V,
-                              FeatureName.str());
-        }
-      }
-    }
-  }
+  //  for (const auto &FeatureName : Features.keys()) {
+  //    std::vector<std::string> Frontier(Children[FeatureName].begin(),
+  //                                      Children[FeatureName].end());
+  //    while (!Frontier.empty()) {
+  //      const std::string FName{Frontier.back()};
+  //      Frontier.pop_back();
+  //      if (auto *F = llvm::dyn_cast<Feature>(Features[FName].get());
+  //          F && !F->isOptional()) {
+  //        llvm::SmallSet<Feature *, 3> Xor;
+  //        Xor.insert(F);
+  //        for (const auto &Name : Frontier) {
+  //          if (auto *E = llvm::dyn_cast<Feature>(Features[Name].get());
+  //              E && !E->isOptional()) {
+  //            if (std::all_of(Xor.begin(), Xor.end(), [E](const auto *F) {
+  //                  return isSimpleMutex(F, E);
+  //                })) {
+  //              Xor.insert(E);
+  //            }
+  //          }
+  //        }
+  //        if (Xor.size() > 1) {
+  //          std::vector<std::string> V;
+  //          for (auto *E : Xor) {
+  //            Frontier.erase(std::remove(Frontier.begin(), Frontier.end(),
+  //                                       E->getName().str()),
+  //                           Frontier.end());
+  //            V.push_back(E->getName().str());
+  //            for (auto *R : cleanUpMutualExclusiveConstraints(E, Xor)) {
+  //              E->removeConstraintNonPreserve(R);
+  //            }
+  //          }
+  //          emplaceRelationship(Relationship::RelationshipKind::RK_ALTERNATIVE,
+  //          V,
+  //                              FeatureName.str());
+  //        }
+  //      }
+  //    }
+  //  }
 }
 
 bool FeatureModelBuilder::buildConstraints() {
-  auto B = BuilderVisitor(this);
+  auto B = BuilderVisitor(*this);
   for (const auto &C : Constraints) {
     C->accept(B);
   }
@@ -126,65 +127,67 @@ bool FeatureModelBuilder::buildConstraints() {
 
 bool FeatureModelBuilder::buildTree(Feature &F,
                                     std::set<std::string> &Visited) {
-  if (find(Visited.begin(), Visited.end(), F.getName()) != Visited.end()) {
-    llvm::errs() << "error: Cycle or duplicate edge in \'" << F.getName()
-                 << "\'.\n";
-    return false;
-  }
-  Visited.insert(F.getName().str());
-
-  for (const auto &Child : Children[F.getName()]) {
-    if (Parents[Child] != F.getName()) {
-      llvm::errs() << "error: Parent of \'" << Child << "\' does not match \'"
-                   << F.getName() << "\'.\n";
-      return false;
-    }
-    if (auto *C = getFeature(Child); C) {
-      if (!buildTree(*C, Visited)) {
-        return false;
-      }
-    } else {
-      llvm::errs() << "error: Missing feature \'\'" << F.getName() << "\'.\n";
-    }
-  }
-
-  llvm::SmallSet<std::string, 3> Skip;
-  if (RelationshipEdges.find(F.getName()) != RelationshipEdges.end()) {
-    for (const auto &Pair : RelationshipEdges[F.getName()]) {
-      auto R = std::make_unique<Relationship>(Pair.first);
-      Features[F.getName()]->addEdge(R.get());
-      R->setParent(Features[F.getName()].get());
-      for (const auto &Child : Pair.second) {
-        if (Children[F.getName()].count(Child) == 0) {
-          llvm::errs() << "error: Related node \'" << Child
-                       << "\' is not child of \'" << F.getName() << "\'.\n";
-          return false;
-        }
-        Skip.insert(Child);
-        R->addEdge(Features[Child].get());
-        Features[Child]->setParent(R.get());
-      }
-      Relationships.push_back(std::move(R));
-    }
-  }
-
-  for (const auto &Child : Children[F.getName()]) {
-    if (Skip.count(Child) > 0) {
-      continue;
-    }
-    Features[F.getName()]->addEdge(Features[Child].get());
-    Features[Child]->setParent(Features[F.getName()].get());
-  }
+  //  if (find(Visited.begin(), Visited.end(), F.getName()) != Visited.end()) {
+  //    llvm::errs() << "error: Cycle or duplicate edge in \'" << F.getName()
+  //                 << "\'.\n";
+  //    return false;
+  //  }
+  //  Visited.insert(F.getName().str());
+  //
+  //  for (const auto &Child : Children[F.getName()]) {
+  //    if (Parents[Child] != F.getName()) {
+  //      llvm::errs() << "error: Parent of \'" << Child << "\' does not match
+  //      \'"
+  //                   << F.getName() << "\'.\n";
+  //      return false;
+  //    }
+  //    if (auto *C = getFeature(Child); C) {
+  //      if (!buildTree(*C, Visited)) {
+  //        return false;
+  //      }
+  //    } else {
+  //      llvm::errs() << "error: Missing feature \'\'" << F.getName() <<
+  //      "\'.\n";
+  //    }
+  //  }
+  //
+  //  llvm::SmallSet<std::string, 3> Skip;
+  //  if (RelationshipEdges.find(F.getName()) != RelationshipEdges.end()) {
+  //    for (const auto &Pair : RelationshipEdges[F.getName()]) {
+  //      auto R = std::make_unique<Relationship>(Pair.first);
+  //      Features[F.getName()]->addEdge(R.get());
+  //      R->setParent(Features[F.getName()].get());
+  //      for (const auto &Child : Pair.second) {
+  //        if (Children[F.getName()].count(Child) == 0) {
+  //          llvm::errs() << "error: Related node \'" << Child
+  //                       << "\' is not child of \'" << F.getName() << "\'.\n";
+  //          return false;
+  //        }
+  //        Skip.insert(Child);
+  //        R->addEdge(Features[Child].get());
+  //        Features[Child]->setParent(R.get());
+  //      }
+  //      Relationships.push_back(std::move(R));
+  //    }
+  //  }
+  //
+  //  for (const auto &Child : Children[F.getName()]) {
+  //    if (Skip.count(Child) > 0) {
+  //      continue;
+  //    }
+  //    Features[F.getName()]->addEdge(Features[Child].get());
+  //    Features[Child]->setParent(Features[F.getName()].get());
+  //  }
 
   return true;
 }
 
 bool FeatureModelBuilder::buildRoot() {
-  for (auto *Child : Root->children()) {
-    if (auto *C = llvm::dyn_cast<Feature>(Child);
-        C && Parents[C->getName()].empty()) {
-      Children[Root->getName()].insert(C->getName().str());
-      Parents[C->getName()] = Root->getName();
+  if (!FM->getRoot()) {
+    auto T = FeatureModelModifyTransaction::openTransaction(*FM);
+    T.setRoot(std::make_unique<RootFeature>("root"));
+    if (!T.commit()) {
+      return false;
     }
   }
   return true;
@@ -192,12 +195,21 @@ bool FeatureModelBuilder::buildRoot() {
 
 std::unique_ptr<FeatureModel> FeatureModelBuilder::buildFeatureModel() {
   std::set<std::string> Visited;
-  if (!buildRoot() || !buildConstraints() || !buildTree(*Root, Visited)) {
+  if (!buildRoot() || !Features.commit() || !Transactions.commit() ||
+      !buildConstraints()) {
     return nullptr;
   }
-  return std::make_unique<FeatureModel>(Name, Path, Commit, std::move(Features),
-                                        std::move(Constraints),
-                                        std::move(Relationships), Root);
+  //  if (!FM->getRoot()) {
+  //    auto T = FeatureModelModifyTransaction::openTransaction(*FM);
+  //    T.setRoot(std::make_unique<RootFeature>("root"));
+  //    T.commit();
+  //  }
+  //  if (!buildRoot() ||  || !buildTree(*Root, Visited))
+  //    {
+  //    return nullptr;
+  //  }
+  //  buildRoot();
+  return std::move(FM);
 }
 
 } // namespace vara::feature

--- a/lib/Feature/FeatureModelBuilder.cpp
+++ b/lib/Feature/FeatureModelBuilder.cpp
@@ -196,7 +196,7 @@ bool FeatureModelBuilder::buildRoot() {
 std::unique_ptr<FeatureModel> FeatureModelBuilder::buildFeatureModel() {
   std::set<std::string> Visited;
   if (!buildRoot() || !Features.commit() || !Transactions.commit() ||
-      !buildConstraints()) {
+      !PostTransactions.commit() || !buildConstraints()) {
     return nullptr;
   }
   //  if (!FM->getRoot()) {

--- a/lib/Feature/FeatureModelBuilder.cpp
+++ b/lib/Feature/FeatureModelBuilder.cpp
@@ -54,15 +54,10 @@ bool FeatureModelBuilder::detectXMLAlternatives() {
     auto Children = F->getChildren<Feature>();
     if (Children.size() > 1 &&
         std::all_of(Children.begin(), Children.end(), [Children](auto *F) {
-          for (auto *C : Children) {
-            if (F == C) {
-              continue;
-            }
-            if (!isSimpleMutex(F, C)) {
-              return false;
-            }
-          }
-          return !F->isOptional();
+          return !F->isOptional() &&
+                 std::all_of(Children.begin(), Children.end(), [F](auto *C) {
+                   return F == C || isSimpleMutex(F, C);
+                 });
         })) {
       Special.addRelationship(Relationship::RelationshipKind::RK_ALTERNATIVE,
                               F);

--- a/lib/Feature/FeatureModelParser.cpp
+++ b/lib/Feature/FeatureModelParser.cpp
@@ -386,8 +386,7 @@ bool FeatureModelSxfmParser::parseFeatureTree(xmlNode *FeatureTree) {
     // Each entry represents an or group as a tuple where the first value is
     // the name of the parent, the second is the relationship kind, and the
     // third a vector consisting of the name of the children
-    std::map<int, std::tuple<std::string, Relationship::RelationshipKind,
-                             std::vector<std::string>>>
+    std::map<int, std::tuple<std::string, Relationship::RelationshipKind>>
         OrGroupMapping;
 
     if (FeatureTree == nullptr) {
@@ -527,7 +526,6 @@ bool FeatureModelSxfmParser::parseFeatureTree(xmlNode *FeatureTree) {
       auto OrGroup = OrGroupMapping.find(CurrentIndentationLevel);
       if (OrGroup != OrGroupMapping.end()) {
         FMB.emplaceRelationship(std::get<1>(OrGroup->second),
-                                std::get<2>(OrGroup->second),
                                 std::get<0>(OrGroup->second));
         OrGroupMapping.erase(CurrentIndentationLevel);
       }
@@ -540,15 +538,8 @@ bool FeatureModelSxfmParser::parseFeatureTree(xmlNode *FeatureTree) {
           GroupKind = Relationship::RelationshipKind::RK_OR;
         }
         OrGroupMapping[CurrentIndentationLevel] =
-            std::tuple<std::string, Relationship::RelationshipKind,
-                       std::vector<std::string>>(Name, GroupKind,
-                                                 std::vector<std::string>());
-      }
-
-      // Add a child
-      OrGroup = OrGroupMapping.find(CurrentIndentationLevel - 1);
-      if (OrGroup != OrGroupMapping.end()) {
-        std::get<2>(OrGroup->second).push_back(Name);
+            std::tuple<std::string, Relationship::RelationshipKind>(Name,
+                                                                    GroupKind);
       }
 
       LastIndentationLevel = CurrentIndentationLevel;
@@ -557,7 +548,6 @@ bool FeatureModelSxfmParser::parseFeatureTree(xmlNode *FeatureTree) {
     // Add the remaining or groups
     for (auto &OrGroup : OrGroupMapping) {
       FMB.emplaceRelationship(std::get<1>(OrGroup.second),
-                              std::get<2>(OrGroup.second),
                               std::get<0>(OrGroup.second));
     }
   }

--- a/lib/Feature/FeatureModelParser.cpp
+++ b/lib/Feature/FeatureModelParser.cpp
@@ -99,7 +99,7 @@ bool FeatureModelXmlParser::parseConfigurationOption(xmlNode *Node,
 
   // XML has those names specified as root nodes
   if (Name == "root" || Name == "base") {
-    FMB.setRootName(Name);
+    FMB.setRoot(Name);
     return FMB.makeFeature<RootFeature>(Name);
   }
   if (Num) {

--- a/lib/Feature/FeatureModelParser.cpp
+++ b/lib/Feature/FeatureModelParser.cpp
@@ -317,7 +317,6 @@ FeatureModelParser::UniqueXmlDoc FeatureModelXmlParser::parseDoc() {
   return UniqueXmlDoc(nullptr, nullptr);
 }
 
-// TODO(s9latimm): replace with builder err
 bool FeatureModelXmlParser::verifyFeatureModel() { return parseDoc().get(); }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Feature/FeatureModelParser.cpp
+++ b/lib/Feature/FeatureModelParser.cpp
@@ -99,7 +99,7 @@ bool FeatureModelXmlParser::parseConfigurationOption(xmlNode *Node,
 
   // XML has those names specified as root nodes
   if (Name == "root" || Name == "base") {
-    FMB.setRoot(Name);
+    FMB.makeRoot(Name);
     return FMB.makeFeature<RootFeature>(Name);
   }
   if (Num) {

--- a/lib/Feature/FeatureModelParser.cpp
+++ b/lib/Feature/FeatureModelParser.cpp
@@ -238,7 +238,6 @@ std::unique_ptr<FeatureModel> FeatureModelXmlParser::buildFeatureModel() {
   if (!Doc) {
     return nullptr;
   }
-  FMB.init();
   return parseVm(xmlDocGetRootElement(Doc.get())) ? FMB.buildFeatureModel()
                                                   : nullptr;
 }
@@ -290,8 +289,6 @@ std::unique_ptr<FeatureModel> FeatureModelSxfmParser::buildFeatureModel() {
   if (!Doc) {
     return nullptr;
   }
-
-  FMB.init();
   return parseVm(xmlDocGetRootElement(Doc.get())) ? FMB.buildFeatureModel()
                                                   : nullptr;
 }

--- a/lib/Feature/FeatureModelTransaction.cpp
+++ b/lib/Feature/FeatureModelTransaction.cpp
@@ -4,17 +4,17 @@
 
 namespace vara::feature {
 
+bool mergeSubtree(FeatureModelCopyTransaction &Trans, FeatureModel &FM,
+                  Feature &F);
+std::unique_ptr<Feature> FeatureSoftCopy(Feature *F);
+bool FeatureSoftCompare(const Feature &F1, const Feature &F2);
+
 void addFeature(FeatureModel &FM, std::unique_ptr<Feature> NewFeature,
                 Feature *Parent) {
   auto Trans = FeatureModelModifyTransaction::openTransaction(FM);
   Trans.addFeature(std::move(NewFeature), Parent);
   Trans.commit();
 }
-
-bool mergeSubtree(FeatureModelCopyTransaction &Trans, FeatureModel &FM,
-                  Feature &F);
-std::unique_ptr<Feature> FeatureSoftCopy(Feature *pFeature);
-bool FeatureSoftCompare(const Feature &F1, const Feature &F2);
 
 [[nodiscard]] std::unique_ptr<FeatureModel>
 mergeFeatureModels(FeatureModel &FM1, FeatureModel &FM2) {
@@ -103,8 +103,8 @@ mergeFeatureModels(FeatureModel &FM1, FeatureModel &FM2) {
   if (F1.getKind() == Feature::FeatureKind::FK_BINARY) {
     return true;
   }
-  if (auto *NF1 = llvm::dyn_cast<NumericFeature>(&F1)) {
-    if (auto *NF2 = llvm::dyn_cast<NumericFeature>(&F2)) {
+  if (const auto *NF1 = llvm::dyn_cast<NumericFeature>(&F1)) {
+    if (const auto *NF2 = llvm::dyn_cast<NumericFeature>(&F2)) {
       return NF1->getValues() == NF2->getValues();
     }
   }

--- a/lib/Feature/FeatureModelTransaction.cpp
+++ b/lib/Feature/FeatureModelTransaction.cpp
@@ -22,9 +22,8 @@ mergeFeatureModels(FeatureModel &FM1, FeatureModel &FM2) {
   if (!mergeSubtree(Trans, FM1, *FM2.getRoot())) {
     Trans.abort();
     return nullptr;
-  } else {
-    return Trans.commit();
   }
+  return Trans.commit();
 }
 
 [[nodiscard]] bool mergeSubtree(FeatureModelCopyTransaction &Trans,

--- a/lib/Feature/FeatureModelTransaction.cpp
+++ b/lib/Feature/FeatureModelTransaction.cpp
@@ -35,8 +35,7 @@ mergeFeatureModels(FeatureModel &FM1, FeatureModel &FM2) {
       for (FeatureSourceRange const &FSR : F.getLocations()) {
         if (std::find(CMP->getLocationsBegin(), CMP->getLocationsEnd(), FSR) ==
             CMP->getLocationsEnd()) {
-          // CMP->addLocation(FSR);
-          // TODO: implement transaction to add locations
+          CMP->addLocation(FSR);
         }
       }
     } else {

--- a/lib/Feature/FeatureModelTransaction.cpp
+++ b/lib/Feature/FeatureModelTransaction.cpp
@@ -11,4 +11,104 @@ void addFeature(FeatureModel &FM, std::unique_ptr<Feature> NewFeature,
   Trans.commit();
 }
 
+bool mergeSubtree(FeatureModelCopyTransaction &Trans, FeatureModel &FM,
+                  Feature &F);
+std::unique_ptr<Feature> FeatureSoftCopy(Feature *pFeature);
+bool FeatureSoftCompare(const Feature &F1, const Feature &F2);
+
+[[nodiscard]] std::unique_ptr<FeatureModel>
+mergeFeatureModels(FeatureModel &FM1, FeatureModel &FM2) {
+  auto Trans = FeatureModelCopyTransaction::openTransaction(FM1);
+  if (!mergeSubtree(Trans, FM1, *FM2.getRoot())) {
+    return nullptr;
+  } else {
+    return Trans.commit();
+  }
+}
+
+[[nodiscard]] bool mergeSubtree(FeatureModelCopyTransaction &Trans,
+                                FeatureModel &FM, Feature &F) {
+  // Is there a similar Feature in the other FM
+  if (Feature *CMP = FM.getFeature(F.getName())) {
+    if (FeatureSoftCompare(*CMP, F)) {
+      // similar feature, maybe merge locations
+      for (FeatureSourceRange &FSR : F.getLocations()) {
+        if (std::find(CMP->getLocationsBegin(), CMP->getLocationsEnd(), FSR) ==
+            CMP->getLocationsEnd()) {
+          CMP->addLocation(FSR);
+        }
+      }
+    } else {
+      Trans.abort();
+      return false;
+    }
+  } else {
+    std::unique_ptr<Feature> SoftCopy = FeatureSoftCopy(&F);
+    if (!SoftCopy) {
+      Trans.abort();
+      return false;
+    }
+    Trans.addFeature(std::move(SoftCopy), F.getParentFeature());
+  }
+
+  // copy children  if missing
+  for (Feature *Child : F.getChildren<Feature>()) {
+    if (!mergeSubtree(Trans, FM, *Child)) {
+      // aborted in callee
+      return false;
+    }
+  }
+  return true;
+}
+
+[[nodiscard]] std::unique_ptr<Feature> FeatureSoftCopy(Feature *F) {
+  std::unique_ptr<Feature> FeatureSoftCopy;
+  NumericFeature::ValuesVariantType Values;
+  switch (F->getKind()) {
+  case Feature::FeatureKind::FK_BINARY:
+    return std::make_unique<BinaryFeature>(
+        F->getName(), F->isOptional(),
+        std::vector<FeatureSourceRange>(F->getLocationsBegin(),
+                                        F->getLocationsEnd()));
+  case Feature::FeatureKind::FK_NUMERIC:
+    Values = dynamic_cast<NumericFeature *>(F)->getValues();
+    return std::make_unique<NumericFeature>(
+        F->getName(), Values, F->isOptional(),
+        std::vector<FeatureSourceRange>(F->getLocationsBegin(),
+                                        F->getLocationsEnd()));
+  case Feature::FeatureKind::FK_ROOT:
+    return std::make_unique<RootFeature>();
+  case Feature::FeatureKind::FK_UNKNOWN:
+    return nullptr;
+  }
+}
+
+[[nodiscard]] bool FeatureSoftCompare(const Feature &F1, const Feature &F2) {
+  assert(F1.getName() == F2.getName());
+  if (F1.getKind() != F2.getKind()) {
+    return false;
+  }
+  if (F1.isOptional() != F2.isOptional()) {
+    return false;
+  }
+  if (F1.getKind() == Feature::FeatureKind::FK_ROOT) {
+    return true;
+  }
+  if (*(F1.getParentFeature()) != *(F2.getParentFeature())) {
+    return false;
+  }
+  if (F1.getParent()->getKind() != F2.getParent()->getKind()) {
+    return false;
+  }
+  if (F1.getKind() == Feature::FeatureKind::FK_BINARY) {
+    return true;
+  }
+  if (auto *NF1 = llvm::dyn_cast<NumericFeature>(&F1)) {
+    if (auto *NF2 = llvm::dyn_cast<NumericFeature>(&F2)) {
+      return NF1->getValues() == NF2->getValues();
+    }
+  }
+  return false;
+}
+
 } // namespace vara::feature

--- a/lib/Feature/FeatureModelTransaction.cpp
+++ b/lib/Feature/FeatureModelTransaction.cpp
@@ -35,7 +35,7 @@ mergeFeatureModels(FeatureModel &FM1, FeatureModel &FM2) {
       for (FeatureSourceRange const &FSR : F.getLocations()) {
         if (std::find(CMP->getLocationsBegin(), CMP->getLocationsEnd(), FSR) ==
             CMP->getLocationsEnd()) {
-          CMP->addLocation(FSR);
+          Trans.addLocation(CMP, FSR);
         }
       }
     } else {

--- a/lib/Feature/FeatureModelTransaction.cpp
+++ b/lib/Feature/FeatureModelTransaction.cpp
@@ -73,7 +73,7 @@ mergeFeatureModels(FeatureModel &FM1, FeatureModel &FM2) {
                                           F.getLocationsEnd()));
     }
   case Feature::FeatureKind::FK_ROOT:
-    return std::make_unique<RootFeature>();
+    return std::make_unique<RootFeature>(F.getName().str());
   default:
     break;
   }

--- a/lib/Feature/FeatureModelTransaction.cpp
+++ b/lib/Feature/FeatureModelTransaction.cpp
@@ -67,18 +67,18 @@ mergeFeatureModels(FeatureModel &FM1, FeatureModel &FM2) {
   switch (F->getKind()) {
   case Feature::FeatureKind::FK_BINARY:
     return std::make_unique<BinaryFeature>(
-        F->getName(), F->isOptional(),
+        F->getName().str(), F->isOptional(),
         std::vector<FeatureSourceRange>(F->getLocationsBegin(),
                                         F->getLocationsEnd()));
   case Feature::FeatureKind::FK_NUMERIC:
     Values = dynamic_cast<NumericFeature *>(F)->getValues();
     return std::make_unique<NumericFeature>(
-        F->getName(), Values, F->isOptional(),
+        F->getName().str(), Values, F->isOptional(),
         std::vector<FeatureSourceRange>(F->getLocationsBegin(),
                                         F->getLocationsEnd()));
   case Feature::FeatureKind::FK_ROOT:
     return std::make_unique<RootFeature>();
-  case Feature::FeatureKind::FK_UNKNOWN:
+  default:
     return nullptr;
   }
 }

--- a/lib/Feature/FeatureModelTransaction.cpp
+++ b/lib/Feature/FeatureModelTransaction.cpp
@@ -16,6 +16,12 @@ void addFeature(FeatureModel &FM, std::unique_ptr<Feature> NewFeature,
   Trans.commit();
 }
 
+void setCommit(FeatureModel &FM, std::string NewCommit) {
+  auto Trans = FeatureModelModifyTransaction::openTransaction(FM);
+  Trans.setCommit(std::move(NewCommit));
+  Trans.commit();
+}
+
 [[nodiscard]] std::unique_ptr<FeatureModel>
 mergeFeatureModels(FeatureModel &FM1, FeatureModel &FM2) {
   auto Trans = FeatureModelCopyTransaction::openTransaction(FM1);

--- a/lib/Feature/FeatureModelTransaction.cpp
+++ b/lib/Feature/FeatureModelTransaction.cpp
@@ -29,7 +29,7 @@ mergeFeatureModels(FeatureModel &FM1, FeatureModel &FM2) {
 
 [[nodiscard]] bool mergeSubtree(FeatureModelCopyTransaction &Trans,
                                 FeatureModel const &FM, Feature &F) {
-  // Is there a similar Feature in the other FM
+  // Is there a similar Feature in the original FM
   if (Feature *CMP = FM.getFeature(F.getName())) {
     if (CompareProperties(*CMP, F)) {
       // similar feature, maybe merge locations
@@ -44,14 +44,14 @@ mergeFeatureModels(FeatureModel &FM1, FeatureModel &FM2) {
       return false;
     }
   } else {
-    std::unique_ptr<Feature> SoftCopy = FeatureCopy(&F);
-    if (!SoftCopy) {
+    std::unique_ptr<Feature> Copy = FeatureCopy(&F);
+    if (!Copy) {
       return false;
     }
-    Trans.addFeature(std::move(SoftCopy), F.getParentFeature());
+    Trans.addFeature(std::move(Copy), F.getParentFeature());
   }
 
-  // copy children  if missing
+  // copy children if missing
   for (Feature *Child : F.getChildren<Feature>()) {
     if (!mergeSubtree(Trans, FM, *Child)) {
       return false;

--- a/lib/Feature/FeatureModelWriter.cpp
+++ b/lib/Feature/FeatureModelWriter.cpp
@@ -286,7 +286,10 @@ int FeatureModelXmlWriter::writeFeature(xmlTextWriterPtr Writer,
         if (LHS->getFeature() &&
             LHS->getFeature()->getName() == Feature1.getName() &&
             RHS->getFeature()) {
-          Excludes.insert(RHS->getFeature());
+          if (std::find(Excludes.begin(), Excludes.end(), RHS->getFeature()) ==
+              Excludes.end()) {
+            Excludes.insert(RHS->getFeature());
+          }
         }
       }
     }

--- a/lib/Feature/FeatureModelWriter.cpp
+++ b/lib/Feature/FeatureModelWriter.cpp
@@ -1,5 +1,6 @@
 #include "vara/Feature/FeatureModelWriter.h"
 #include "vara/Feature/FeatureModel.h"
+#include "vara/Feature/OrderedFeatureVector.h"
 
 #include <llvm/Support/Casting.h>
 
@@ -218,7 +219,7 @@ int FeatureModelXmlWriter::writeFeature(xmlTextWriterPtr Writer,
 
   // children
   auto FS = Feature1.getChildren<Feature>();
-  auto Children = OrderedFeatureVector(FS.begin(), FS.end());
+  auto Children = deprecated::OrderedFeatureVector(FS.begin(), FS.end());
 
   if (!Children.empty()) {
     RC = xmlTextWriterStartElement(Writer, XmlConstants::CHILDREN);
@@ -235,7 +236,7 @@ int FeatureModelXmlWriter::writeFeature(xmlTextWriterPtr Writer,
   }
 
   // implications
-  OrderedFeatureVector Implications;
+  deprecated::OrderedFeatureVector Implications;
 
   for (const auto *C : Feature1.implications()) {
     if (const auto *LHS =
@@ -268,7 +269,7 @@ int FeatureModelXmlWriter::writeFeature(xmlTextWriterPtr Writer,
   }
 
   // excludes
-  OrderedFeatureVector Excludes;
+  deprecated::OrderedFeatureVector Excludes;
 
   if (llvm::isa_and_nonnull<Relationship>(Feature1.getParent())) {
     auto ES = Feature1.getParent()->getChildren<Feature>();

--- a/lib/Feature/OrderedFeatureVector.cpp
+++ b/lib/Feature/OrderedFeatureVector.cpp
@@ -2,7 +2,8 @@
 
 #include <iterator>
 
-namespace vara::feature {
+namespace vara::feature::deprecated {
+
 void OrderedFeatureVector::insert(Feature *F) {
   Features.insert(
       std::upper_bound(Features.begin(), Features.end(), F,
@@ -10,4 +11,5 @@ void OrderedFeatureVector::insert(Feature *F) {
                           vara::feature::Feature *B) { return *A < *B; }),
       F);
 }
-} // namespace vara::feature
+
+} // namespace vara::feature::deprecated

--- a/unittests/Feature/BinaryFeature.cpp
+++ b/unittests/Feature/BinaryFeature.cpp
@@ -21,15 +21,6 @@ TEST(BinaryFeature, isa) {
   EXPECT_FALSE(llvm::isa<RootFeature>(A));
 }
 
-TEST(BinaryFeature, BinaryFeatureRoot) {
-  auto B = FeatureModelBuilder();
-
-  B.makeFeature<BinaryFeature>("F");
-  B.setRoot("F");
-
-  EXPECT_FALSE(B.buildFeatureModel());
-}
-
 TEST(BinaryFeature, BinaryFeatureChildren) {
   FeatureModelBuilder B;
   B.makeFeature<BinaryFeature>("a");
@@ -38,7 +29,7 @@ TEST(BinaryFeature, BinaryFeatureChildren) {
   auto FM = B.buildFeatureModel();
   assert(FM);
 
-  EXPECT_EQ(
+  ASSERT_EQ(
       std::distance(FM->getFeature("a")->begin(), FM->getFeature("a")->end()),
       1);
   if (auto *F = llvm::dyn_cast<Feature>(*FM->getFeature("a")->begin())) {

--- a/unittests/Feature/BinaryFeature.cpp
+++ b/unittests/Feature/BinaryFeature.cpp
@@ -27,7 +27,7 @@ TEST(BinaryFeature, BinaryFeatureChildren) {
   B.addEdge("a", "aa")->makeFeature<BinaryFeature>("aa");
 
   auto FM = B.buildFeatureModel();
-  assert(FM);
+  ASSERT_TRUE(FM);
 
   ASSERT_EQ(
       std::distance(FM->getFeature("a")->begin(), FM->getFeature("a")->end()),

--- a/unittests/Feature/BinaryFeature.cpp
+++ b/unittests/Feature/BinaryFeature.cpp
@@ -1,5 +1,4 @@
-#include "vara/Feature/Feature.h"
-#include "vara/Feature/FeatureModel.h"
+#include "vara/Feature/FeatureModelBuilder.h"
 
 #include "llvm/Support/Casting.h"
 
@@ -26,7 +25,7 @@ TEST(BinaryFeature, BinaryFeatureRoot) {
   auto B = FeatureModelBuilder();
 
   B.makeFeature<BinaryFeature>("F");
-  B.setRootName("F");
+  B.setRoot("F");
 
   EXPECT_FALSE(B.buildFeatureModel());
 }

--- a/unittests/Feature/FeatureModel.cpp
+++ b/unittests/Feature/FeatureModel.cpp
@@ -21,11 +21,11 @@ TEST(FeatureModel, cloneUnique) {
   B.makeFeature<BinaryFeature>("aa")->addEdge("a", "aa");
   B.makeFeature<BinaryFeature>("b");
   auto FM = B.buildFeatureModel();
-  assert(FM);
+  ASSERT_TRUE(FM);
 
   auto Clone = FM->clone();
 
-  assert(Clone);
+  ASSERT_TRUE(Clone);
   for (const auto &Feature : FM->features()) {
     EXPECT_NE(Clone->getFeature(Feature->getName()), Feature);
   }
@@ -35,10 +35,10 @@ TEST(FeatureModel, cloneRoot) {
   FeatureModelBuilder B;
   B.makeRoot("a");
   auto FM = B.buildFeatureModel();
-  assert(FM);
+  ASSERT_TRUE(FM);
 
   auto Clone = FM->clone();
-  assert(Clone);
+  ASSERT_TRUE(Clone);
   FM.reset();
 
   // The inner EXPECT_TRUE just handles the nodiscard of getParent
@@ -54,10 +54,10 @@ TEST(FeatureModel, cloneRelationship) {
   B.makeFeature<BinaryFeature>("ab")->addEdge("a", "ab");
   B.emplaceRelationship(Relationship::RelationshipKind::RK_OR, "a");
   auto FM = B.buildFeatureModel();
-  assert(FM);
+  ASSERT_TRUE(FM);
 
   auto Clone = FM->clone();
-  assert(Clone);
+  ASSERT_TRUE(Clone);
   FM.reset();
 
   EXPECT_FALSE(Clone->getFeature("a")->getChildren<Relationship>().empty());
@@ -71,10 +71,10 @@ TEST(FeatureModel, cloneConstraint) {
   B.addConstraint(std::make_unique<PrimaryFeatureConstraint>(
       std::make_unique<BinaryFeature>("a")));
   auto FM = B.buildFeatureModel();
-  assert(FM);
+  ASSERT_TRUE(FM);
 
   auto Clone = FM->clone();
-  assert(Clone);
+  ASSERT_TRUE(Clone);
   auto *Deleted = *FM->getFeature("a")->constraints().begin();
   FM.reset();
 
@@ -104,7 +104,7 @@ protected:
     B.addEdge("b", "bb")->makeFeature<BinaryFeature>("bb");
     B.makeFeature<BinaryFeature>("c");
     FM = B.buildFeatureModel();
-    assert(FM);
+    ASSERT_TRUE(FM);
   }
 
   std::unique_ptr<FeatureModel> FM;
@@ -128,7 +128,7 @@ TEST_F(FeatureModelTest, disjunct) {
   B.makeFeature<BinaryFeature>("a");
   B.makeFeature<BinaryFeature>("b");
   auto FN = B.buildFeatureModel();
-  assert(FN);
+  ASSERT_TRUE(FN);
 
   EXPECT_NE(*FM->getFeature("a"), *FN->getFeature("b"));
   EXPECT_LT(*FM->getFeature("a"), *FN->getFeature("b"));
@@ -147,7 +147,7 @@ TEST_F(FeatureModelTest, ltSameName) {
   FeatureModelBuilder B;
   B.makeFeature<BinaryFeature>("a");
   auto FN = B.buildFeatureModel();
-  assert(FN);
+  ASSERT_TRUE(FN);
 
   EXPECT_EQ(*FM->getFeature("a"), *FN->getFeature("a"));
   EXPECT_FALSE(*FM->getFeature("a") < *FN->getFeature("a"));
@@ -238,7 +238,7 @@ protected:
     B.addEdge("b", "bb")->makeFeature<BinaryFeature>("bb");
     B.makeFeature<BinaryFeature>("c");
     FM = B.buildFeatureModel();
-    assert(FM);
+    ASSERT_TRUE(FM);
   }
 
   // Dummy method to fulfill the FeatureModelModification interface
@@ -283,12 +283,14 @@ TEST_F(FeatureModelConsistencyCheckerTest,
           *FM));
 }
 
-TEST_F(FeatureModelConsistencyCheckerTest, EveryFMNeedsOneRootExceptEmpty) {
+TEST_F(FeatureModelConsistencyCheckerTest, FMNoRoot) {
   FeatureModel FM;
+
+  FeatureModelModification::removeFeature(FM, *FM.getRoot());
 
   EXPECT_EQ(FM.size(), 0);
   EXPECT_EQ(FM.begin(), FM.end());
-  EXPECT_TRUE(
+  EXPECT_FALSE(
       FeatureModelConsistencyChecker<ExactlyOneRootNode>::isFeatureModelValid(
           FM));
 }

--- a/unittests/Feature/FeatureModel.cpp
+++ b/unittests/Feature/FeatureModel.cpp
@@ -33,8 +33,7 @@ TEST(FeatureModel, cloneUnique) {
 
 TEST(FeatureModel, cloneRoot) {
   FeatureModelBuilder B;
-  B.makeFeature<RootFeature>("a");
-  B.setRoot("a");
+  B.makeRoot("a");
   auto FM = B.buildFeatureModel();
   assert(FM);
 

--- a/unittests/Feature/FeatureModel.cpp
+++ b/unittests/Feature/FeatureModel.cpp
@@ -206,6 +206,20 @@ TEST_F(FeatureModelTest, gtSimple) {
   EXPECT_GT(*FM->getFeature("b"), *FM->getFeature("a"));
 }
 
+TEST_F(FeatureModelTest, dfs) {
+  std::vector<Feature *> Expected = {
+      FM->getFeature("c"), FM->getFeature("bb"),  FM->getFeature("ba"),
+      FM->getFeature("b"), FM->getFeature("ab"),  FM->getFeature("aa"),
+      FM->getFeature("a"), FM->getFeature("root")};
+
+  EXPECT_EQ(Expected.size(), FM->size());
+  for (const auto *F : *FM) {
+    EXPECT_STREQ(Expected.back()->getName().data(), F->getName().data());
+    ASSERT_EQ(*Expected.back(), *F);
+    Expected.pop_back();
+  }
+}
+
 //===----------------------------------------------------------------------===//
 //                    FeatureModelConsistencyChecker Tests
 //===----------------------------------------------------------------------===//

--- a/unittests/Feature/FeatureModel.cpp
+++ b/unittests/Feature/FeatureModel.cpp
@@ -1,5 +1,4 @@
-#include "vara/Feature/FeatureModel.h"
-#include "vara/Feature/Feature.h"
+#include "vara/Feature/FeatureModelBuilder.h"
 #include "vara/Feature/FeatureModelTransaction.h"
 
 #include "llvm/ADT/SetVector.h"
@@ -35,7 +34,7 @@ TEST(FeatureModel, cloneUnique) {
 TEST(FeatureModel, cloneRoot) {
   FeatureModelBuilder B;
   B.makeFeature<RootFeature>("a");
-  B.setRootName("a");
+  B.setRoot("a");
   auto FM = B.buildFeatureModel();
   assert(FM);
 

--- a/unittests/Feature/FeatureModel.cpp
+++ b/unittests/Feature/FeatureModel.cpp
@@ -18,7 +18,7 @@ TEST(FeatureModel, build) {
 TEST(FeatureModel, cloneUnique) {
   FeatureModelBuilder B;
   B.makeFeature<BinaryFeature>("a");
-  B.addEdge("a", "aa")->makeFeature<BinaryFeature>("aa");
+  B.makeFeature<BinaryFeature>("aa")->addEdge("a", "aa");
   B.makeFeature<BinaryFeature>("b");
   auto FM = B.buildFeatureModel();
   assert(FM);
@@ -50,9 +50,9 @@ TEST(FeatureModel, cloneRoot) {
 TEST(FeatureModel, cloneRelationship) {
   FeatureModelBuilder B;
   B.makeFeature<BinaryFeature>("a");
-  B.makeFeature<BinaryFeature>("b");
-  B.emplaceRelationship(Relationship::RelationshipKind::RK_OR, {"a", "b"},
-                        "root");
+  B.makeFeature<BinaryFeature>("aa")->addEdge("a", "aa");
+  B.makeFeature<BinaryFeature>("ab")->addEdge("a", "ab");
+  B.emplaceRelationship(Relationship::RelationshipKind::RK_OR, "a");
   auto FM = B.buildFeatureModel();
   assert(FM);
 
@@ -60,9 +60,9 @@ TEST(FeatureModel, cloneRelationship) {
   assert(Clone);
   FM.reset();
 
-  EXPECT_FALSE(Clone->getRoot()->getChildren<Relationship>().empty());
-  EXPECT_TRUE(llvm::isa<Relationship>(Clone->getFeature("a")->getParent()));
-  EXPECT_TRUE(llvm::isa<Relationship>(Clone->getFeature("b")->getParent()));
+  EXPECT_FALSE(Clone->getFeature("a")->getChildren<Relationship>().empty());
+  EXPECT_TRUE(llvm::isa<Relationship>(Clone->getFeature("aa")->getParent()));
+  EXPECT_TRUE(llvm::isa<Relationship>(Clone->getFeature("ab")->getParent()));
 }
 
 TEST(FeatureModel, cloneConstraint) {

--- a/unittests/Feature/FeatureModel.cpp
+++ b/unittests/Feature/FeatureModel.cpp
@@ -243,10 +243,6 @@ TEST_F(FeatureModelConsistencyCheckerTest, EveryFeatureRequiresParentValid) {
 }
 
 TEST_F(FeatureModelConsistencyCheckerTest, EveryFeatureRequiresParentMissing) {
-  FeatureModelBuilder B;
-  B.makeFeature<BinaryFeature>("a");
-
-  auto FM = B.buildFeatureModel();
   FeatureModelModification::removeParent(*FM->getFeature("a"));
 
   EXPECT_FALSE(FeatureModelConsistencyChecker<
@@ -260,10 +256,6 @@ TEST_F(FeatureModelConsistencyCheckerTest, EveryParentNeedsFeatureAsAChild) {
 
 TEST_F(FeatureModelConsistencyCheckerTest,
        EveryParentNeedsFeatureAsAChildMissing) {
-  FeatureModelBuilder B;
-  B.makeFeature<BinaryFeature>("a");
-  auto FM = B.buildFeatureModel();
-
   FeatureModelModification::removeEdge(*FM->getRoot(), *FM->getFeature("a"));
 
   EXPECT_FALSE(FeatureModelConsistencyChecker<
@@ -277,22 +269,20 @@ TEST_F(FeatureModelConsistencyCheckerTest,
           *FM));
 }
 
-TEST_F(FeatureModelConsistencyCheckerTest, EveryFMNeedsOneRootButNonPresent) {
-  FeatureModelBuilder B;
-  auto FM = B.buildFeatureModel();
+TEST_F(FeatureModelConsistencyCheckerTest, EveryFMNeedsOneRootExceptEmpty) {
+  FeatureModel FM;
 
-  FeatureModelModification::removeFeature(*FM, *FM->getRoot());
-
-  EXPECT_FALSE(
+  EXPECT_EQ(FM.size(), 0);
+  EXPECT_EQ(FM.begin(), FM.end());
+  EXPECT_TRUE(
       FeatureModelConsistencyChecker<ExactlyOneRootNode>::isFeatureModelValid(
-          *FM));
+          FM));
 }
 
 TEST_F(FeatureModelConsistencyCheckerTest,
        EveryFMNeedsOneRootButMultiplePresent) {
-  auto FM = FeatureModelBuilder().buildFeatureModel();
-
-  FeatureModelModification::addFeature(*FM, std::make_unique<RootFeature>("b"));
+  ASSERT_TRUE(FeatureModelModification::addFeature(
+      *FM, std::make_unique<RootFeature>("z")));
 
   EXPECT_FALSE(
       FeatureModelConsistencyChecker<ExactlyOneRootNode>::isFeatureModelValid(

--- a/unittests/Feature/FeatureModel.cpp
+++ b/unittests/Feature/FeatureModel.cpp
@@ -265,7 +265,7 @@ TEST_F(FeatureModelConsistencyCheckerTest,
   B.makeFeature<BinaryFeature>("a");
   auto FM = B.buildFeatureModel();
 
-  FeatureModelModification::removeChild(*FM->getRoot(), *FM->getFeature("a"));
+  FeatureModelModification::removeEdge(*FM->getRoot(), *FM->getFeature("a"));
 
   EXPECT_FALSE(FeatureModelConsistencyChecker<
                CheckFeatureParentChildRelationShip>::isFeatureModelValid(*FM));

--- a/unittests/Feature/FeatureModel.cpp
+++ b/unittests/Feature/FeatureModel.cpp
@@ -68,8 +68,9 @@ TEST(FeatureModel, cloneRelationship) {
 
 TEST(FeatureModel, cloneConstraint) {
   FeatureModelBuilder B;
+  B.makeFeature<BinaryFeature>("a");
   B.addConstraint(std::make_unique<PrimaryFeatureConstraint>(
-      B.makeFeature<BinaryFeature>("a")));
+      std::make_unique<BinaryFeature>("a")));
   auto FM = B.buildFeatureModel();
   assert(FM);
 

--- a/unittests/Feature/FeatureModelBuilder.cpp
+++ b/unittests/Feature/FeatureModelBuilder.cpp
@@ -123,22 +123,25 @@ TEST(FeatureModelBuilder, addNumericFeatureRef) {
   EXPECT_TRUE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("aa")));
 }
 
+//===----------------------------------------------------------------------===//
+//                        XMLAlternatives
+//===----------------------------------------------------------------------===//
+
+#define EXCLUDES_CONSTRAINT(A, B)                                              \
+  std::make_unique<ExcludesConstraint>(                                        \
+      std::make_unique<PrimaryFeatureConstraint>(                              \
+          std::make_unique<BinaryFeature>(A)),                                 \
+      std::make_unique<PrimaryFeatureConstraint>(                              \
+          std::make_unique<BinaryFeature>(B)))
+
 TEST(FeatureModelBuilder, detectXMLAlternativesSimple) {
   FeatureModelBuilder B;
   B.makeFeature<BinaryFeature>("a");
   B.makeFeature<BinaryFeature>("aa", false)->addEdge("a", "aa");
   B.makeFeature<BinaryFeature>("ab", false)->addEdge("a", "ab");
 
-  B.addConstraint(std::make_unique<ExcludesConstraint>(
-      std::make_unique<PrimaryFeatureConstraint>(
-          std::make_unique<BinaryFeature>("aa")),
-      std::make_unique<PrimaryFeatureConstraint>(
-          std::make_unique<BinaryFeature>("ab"))));
-  B.addConstraint(std::make_unique<ExcludesConstraint>(
-      std::make_unique<PrimaryFeatureConstraint>(
-          std::make_unique<BinaryFeature>("ab")),
-      std::make_unique<PrimaryFeatureConstraint>(
-          std::make_unique<BinaryFeature>("aa"))));
+  B.addConstraint(EXCLUDES_CONSTRAINT("aa", "ab"));
+  B.addConstraint(EXCLUDES_CONSTRAINT("ab", "aa"));
   auto FM = B.buildFeatureModel();
   assert(FM);
 
@@ -163,11 +166,7 @@ TEST(FeatureModelBuilder, detectXMLAlternativesBroken) {
   B.makeFeature<BinaryFeature>("aa", false);
   B.makeFeature<BinaryFeature>("ab", false);
 
-  B.addConstraint(std::make_unique<ExcludesConstraint>(
-      std::make_unique<PrimaryFeatureConstraint>(
-          std::make_unique<BinaryFeature>("aa")),
-      std::make_unique<PrimaryFeatureConstraint>(
-          std::make_unique<BinaryFeature>("ab"))));
+  B.addConstraint(EXCLUDES_CONSTRAINT("aa", "ab"));
   auto FM = B.buildFeatureModel();
   assert(FM);
 
@@ -183,16 +182,8 @@ TEST(FeatureModelBuilder, detectXMLAlternativesOptionalBroken) {
   B.makeFeature<BinaryFeature>("aa", false);
   B.makeFeature<BinaryFeature>("ab", true);
 
-  B.addConstraint(std::make_unique<ExcludesConstraint>(
-      std::make_unique<PrimaryFeatureConstraint>(
-          std::make_unique<BinaryFeature>("aa")),
-      std::make_unique<PrimaryFeatureConstraint>(
-          std::make_unique<BinaryFeature>("ab"))));
-  B.addConstraint(std::make_unique<ExcludesConstraint>(
-      std::make_unique<PrimaryFeatureConstraint>(
-          std::make_unique<BinaryFeature>("ab")),
-      std::make_unique<PrimaryFeatureConstraint>(
-          std::make_unique<BinaryFeature>("aa"))));
+  B.addConstraint(EXCLUDES_CONSTRAINT("aa", "ab"));
+  B.addConstraint(EXCLUDES_CONSTRAINT("ab", "aa"));
   auto FM = B.buildFeatureModel();
   assert(FM);
 
@@ -210,36 +201,12 @@ TEST(FeatureModelBuilder, detectXMLAlternativesOutOfOrder) {
   B.makeFeature<BinaryFeature>("ac", false);
   B.makeFeature<BinaryFeature>("ab", false);
 
-  B.addConstraint(std::make_unique<ExcludesConstraint>(
-      std::make_unique<PrimaryFeatureConstraint>(
-          std::make_unique<BinaryFeature>("aa")),
-      std::make_unique<PrimaryFeatureConstraint>(
-          std::make_unique<BinaryFeature>("ab"))));
-  B.addConstraint(std::make_unique<ExcludesConstraint>(
-      std::make_unique<PrimaryFeatureConstraint>(
-          std::make_unique<BinaryFeature>("ab")),
-      std::make_unique<PrimaryFeatureConstraint>(
-          std::make_unique<BinaryFeature>("aa"))));
-  B.addConstraint(std::make_unique<ExcludesConstraint>(
-      std::make_unique<PrimaryFeatureConstraint>(
-          std::make_unique<BinaryFeature>("ac")),
-      std::make_unique<PrimaryFeatureConstraint>(
-          std::make_unique<BinaryFeature>("aa"))));
-  B.addConstraint(std::make_unique<ExcludesConstraint>(
-      std::make_unique<PrimaryFeatureConstraint>(
-          std::make_unique<BinaryFeature>("ab")),
-      std::make_unique<PrimaryFeatureConstraint>(
-          std::make_unique<BinaryFeature>("ac"))));
-  B.addConstraint(std::make_unique<ExcludesConstraint>(
-      std::make_unique<PrimaryFeatureConstraint>(
-          std::make_unique<BinaryFeature>("aa")),
-      std::make_unique<PrimaryFeatureConstraint>(
-          std::make_unique<BinaryFeature>("ac"))));
-  B.addConstraint(std::make_unique<ExcludesConstraint>(
-      std::make_unique<PrimaryFeatureConstraint>(
-          std::make_unique<BinaryFeature>("ac")),
-      std::make_unique<PrimaryFeatureConstraint>(
-          std::make_unique<BinaryFeature>("ab"))));
+  B.addConstraint(EXCLUDES_CONSTRAINT("aa", "ab"));
+  B.addConstraint(EXCLUDES_CONSTRAINT("ab", "aa"));
+  B.addConstraint(EXCLUDES_CONSTRAINT("ac", "aa"));
+  B.addConstraint(EXCLUDES_CONSTRAINT("ab", "ac"));
+  B.addConstraint(EXCLUDES_CONSTRAINT("aa", "ac"));
+  B.addConstraint(EXCLUDES_CONSTRAINT("ac", "ab"));
   auto FM = B.buildFeatureModel();
   assert(FM);
 

--- a/unittests/Feature/FeatureModelBuilder.cpp
+++ b/unittests/Feature/FeatureModelBuilder.cpp
@@ -1,6 +1,6 @@
 #include "vara/Feature/FeatureModelBuilder.h"
-#include "vara/Feature/FeatureModelParser.h"
 
+#include "UnittestHelper.h"
 #include "gtest/gtest.h"
 
 namespace vara::feature {
@@ -10,7 +10,7 @@ TEST(FeatureModelBuilder, addBinaryFeature) {
 
   B.makeFeature<BinaryFeature>("a");
   auto FM = B.buildFeatureModel();
-  assert(FM);
+  ASSERT_TRUE(FM);
 
   EXPECT_EQ(FM->getFeature("a")->getKind(), Feature::FeatureKind::FK_BINARY);
 }
@@ -20,7 +20,7 @@ TEST(FeatureModelBuilder, addNumericFeature) {
 
   B.makeFeature<NumericFeature>("a", std::vector<int>{1, 2, 3});
   auto FM = B.buildFeatureModel();
-  assert(FM);
+  ASSERT_TRUE(FM);
 
   EXPECT_EQ(FM->getFeature("a")->getKind(), Feature::FeatureKind::FK_NUMERIC);
 }
@@ -30,13 +30,13 @@ TEST(FeatureModelBuilder, addOptionalFeature) {
 
   B.makeFeature<BinaryFeature>("a", true);
   auto FM = B.buildFeatureModel();
-  assert(FM);
+  ASSERT_TRUE(FM);
 
   EXPECT_TRUE(FM->getFeature("a")->isOptional());
 }
 
 // TODO(se-passau/VaRA#701): Replace string equals with subtree comparison
-TEST(FeatureModelBuilder, addExcludeConstraint) {
+TEST(FeatureModelBuilder, addImpliedExcludeConstraint) {
   FeatureModelBuilder B;
   B.makeFeature<BinaryFeature>("a");
   B.makeFeature<BinaryFeature>("b");
@@ -51,7 +51,7 @@ TEST(FeatureModelBuilder, addExcludeConstraint) {
   B.addConstraint(std::move(C));
 
   auto FM = B.buildFeatureModel();
-  assert(FM);
+  ASSERT_TRUE(FM);
 
   EXPECT_EQ(
       (*FM->getFeature("a")->constraints().begin())->getRoot()->toString(),
@@ -59,20 +59,16 @@ TEST(FeatureModelBuilder, addExcludeConstraint) {
 }
 
 // TODO(se-passau/VaRA#701): Replace string equals with subtree comparison
-TEST(FeatureModelBuilder, addImplicationConstraint) {
+TEST(FeatureModelBuilder, addImpliesConstraint) {
   FeatureModelBuilder B;
   B.makeFeature<BinaryFeature>("a");
   B.makeFeature<BinaryFeature>("b");
-  auto C = std::make_unique<ImpliesConstraint>(
-      std::make_unique<PrimaryFeatureConstraint>(
-          std::make_unique<Feature>("a")),
-      std::make_unique<PrimaryFeatureConstraint>(
-          std::make_unique<Feature>("b")));
+  auto C = createBinaryConstraint<ImpliesConstraint>("a", "b");
   auto Expected = C->toString();
 
   B.addConstraint(std::move(C));
   auto FM = B.buildFeatureModel();
-  assert(FM);
+  ASSERT_TRUE(FM);
 
   EXPECT_EQ(
       (*FM->getFeature("a")->constraints().begin())->getRoot()->toString(),
@@ -84,16 +80,12 @@ TEST(FeatureModelBuilder, addOrConstraint) {
   FeatureModelBuilder B;
   B.makeFeature<BinaryFeature>("a");
   B.makeFeature<BinaryFeature>("b");
-  auto C =
-      std::make_unique<OrConstraint>(std::make_unique<PrimaryFeatureConstraint>(
-                                         std::make_unique<Feature>("a")),
-                                     std::make_unique<PrimaryFeatureConstraint>(
-                                         std::make_unique<Feature>("b")));
+  auto C = createBinaryConstraint<OrConstraint>("a", "b");
   auto Expected = C->toString();
 
   B.addConstraint(std::move(C));
   auto FM = B.buildFeatureModel();
-  assert(FM);
+  ASSERT_TRUE(FM);
 
   EXPECT_EQ(
       (*FM->getFeature("a")->constraints().begin())->getRoot()->toString(),
@@ -106,7 +98,7 @@ TEST(FeatureModelBuilder, addBinaryFeatureRef) {
   B.makeFeature<BinaryFeature>("aa");
   B.addEdge("a", "aa")->makeFeature<BinaryFeature>("a");
   auto FM = B.buildFeatureModel();
-  assert(FM);
+  ASSERT_TRUE(FM);
 
   EXPECT_EQ(FM->getFeature("a")->getKind(), Feature::FeatureKind::FK_BINARY);
   EXPECT_TRUE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("aa")));
@@ -118,120 +110,10 @@ TEST(FeatureModelBuilder, addNumericFeatureRef) {
   B.makeFeature<NumericFeature>("a", std::vector<int>{1, 2, 3});
   B.addEdge("a", "aa")->makeFeature<BinaryFeature>("aa");
   auto FM = B.buildFeatureModel();
-  assert(FM);
+  ASSERT_TRUE(FM);
 
   EXPECT_EQ(FM->getFeature("a")->getKind(), Feature::FeatureKind::FK_NUMERIC);
   EXPECT_TRUE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("aa")));
-}
-
-//===----------------------------------------------------------------------===//
-//                        XMLAlternatives
-//===----------------------------------------------------------------------===//
-
-#define EXCLUDES_CONSTRAINT(A, B)                                              \
-  std::make_unique<ExcludesConstraint>(                                        \
-      std::make_unique<PrimaryFeatureConstraint>(                              \
-          std::make_unique<BinaryFeature>(A)),                                 \
-      std::make_unique<PrimaryFeatureConstraint>(                              \
-          std::make_unique<BinaryFeature>(B)))
-
-TEST(FeatureModelBuilder, detectXMLAlternativesSimple) {
-  FeatureModelBuilder B;
-  B.makeFeature<BinaryFeature>("a");
-  B.makeFeature<BinaryFeature>("aa", false)->addEdge("a", "aa");
-  B.makeFeature<BinaryFeature>("ab", false)->addEdge("a", "ab");
-
-  B.addConstraint(EXCLUDES_CONSTRAINT("aa", "ab"));
-  B.addConstraint(EXCLUDES_CONSTRAINT("ab", "aa"));
-  auto FM = B.buildFeatureModel();
-  assert(FM);
-
-  ASSERT_TRUE(FeatureModelXmlParser::detectXMLAlternatives(*FM));
-
-  EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("aa")));
-  EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ab")));
-  if (auto *R = llvm::dyn_cast<Relationship>(*FM->getFeature("a")->begin());
-      R) {
-    EXPECT_TRUE(R->getKind() == Relationship::RelationshipKind::RK_ALTERNATIVE);
-    EXPECT_TRUE(R->hasEdgeFrom(*FM->getFeature("a")));
-    EXPECT_TRUE(R->hasEdgeTo(*FM->getFeature("aa")));
-    EXPECT_TRUE(R->hasEdgeTo(*FM->getFeature("ab")));
-  } else {
-    FAIL();
-  }
-}
-
-TEST(FeatureModelBuilder, detectXMLAlternativesBroken) {
-  FeatureModelBuilder B;
-  B.makeFeature<BinaryFeature>("a");
-  B.addEdge("a", "aa");
-  B.addEdge("a", "ab");
-  B.makeFeature<BinaryFeature>("aa", false);
-  B.makeFeature<BinaryFeature>("ab", false);
-
-  B.addConstraint(EXCLUDES_CONSTRAINT("aa", "ab"));
-  auto FM = B.buildFeatureModel();
-  assert(FM);
-
-  ASSERT_TRUE(FeatureModelXmlParser::detectXMLAlternatives(*FM));
-
-  EXPECT_TRUE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("aa")));
-  EXPECT_TRUE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ab")));
-}
-
-TEST(FeatureModelBuilder, detectXMLAlternativesOptionalBroken) {
-  FeatureModelBuilder B;
-  B.makeFeature<BinaryFeature>("a");
-  B.addEdge("a", "aa");
-  B.addEdge("a", "ab");
-  B.makeFeature<BinaryFeature>("aa", false);
-  B.makeFeature<BinaryFeature>("ab", true);
-
-  B.addConstraint(EXCLUDES_CONSTRAINT("aa", "ab"));
-  B.addConstraint(EXCLUDES_CONSTRAINT("ab", "aa"));
-  auto FM = B.buildFeatureModel();
-  assert(FM);
-
-  ASSERT_TRUE(FeatureModelXmlParser::detectXMLAlternatives(*FM));
-
-  EXPECT_TRUE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("aa")));
-  EXPECT_TRUE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ab")));
-}
-
-TEST(FeatureModelBuilder, detectXMLAlternativesOutOfOrder) {
-  FeatureModelBuilder B;
-  B.makeFeature<BinaryFeature>("a");
-  B.addEdge("a", "ab");
-  B.addEdge("a", "aa");
-  B.addEdge("a", "ac");
-  B.makeFeature<BinaryFeature>("aa", false);
-  B.makeFeature<BinaryFeature>("ac", false);
-  B.makeFeature<BinaryFeature>("ab", false);
-
-  B.addConstraint(EXCLUDES_CONSTRAINT("aa", "ab"));
-  B.addConstraint(EXCLUDES_CONSTRAINT("ab", "aa"));
-  B.addConstraint(EXCLUDES_CONSTRAINT("ac", "aa"));
-  B.addConstraint(EXCLUDES_CONSTRAINT("ab", "ac"));
-  B.addConstraint(EXCLUDES_CONSTRAINT("aa", "ac"));
-  B.addConstraint(EXCLUDES_CONSTRAINT("ac", "ab"));
-  auto FM = B.buildFeatureModel();
-  assert(FM);
-
-  ASSERT_TRUE(FeatureModelXmlParser::detectXMLAlternatives(*FM));
-
-  EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("aa")));
-  EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ab")));
-  EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ac")));
-  if (auto *R = llvm::dyn_cast<Relationship>(*FM->getFeature("a")->begin());
-      R) {
-    EXPECT_TRUE(R->getKind() == Relationship::RelationshipKind::RK_ALTERNATIVE);
-    EXPECT_TRUE(R->hasEdgeFrom(*FM->getFeature("a")));
-    EXPECT_TRUE(R->hasEdgeTo(*FM->getFeature("aa")));
-    EXPECT_TRUE(R->hasEdgeTo(*FM->getFeature("ab")));
-    EXPECT_TRUE(R->hasEdgeTo(*FM->getFeature("ac")));
-  } else {
-    FAIL();
-  }
 }
 
 } // namespace vara::feature

--- a/unittests/Feature/FeatureModelBuilder.cpp
+++ b/unittests/Feature/FeatureModelBuilder.cpp
@@ -1,4 +1,5 @@
 #include "vara/Feature/FeatureModelBuilder.h"
+#include "vara/Feature/FeatureModelParser.h"
 
 #include "gtest/gtest.h"
 
@@ -145,6 +146,8 @@ TEST(FeatureModelBuilder, detectXMLAlternativesSimple) {
   auto FM = B.buildFeatureModel();
   assert(FM);
 
+  ASSERT_TRUE(FeatureModelXmlParser::detectXMLAlternatives(*FM));
+
   EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("aa")));
   EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ab")));
   if (auto *R = llvm::dyn_cast<Relationship>(*FM->getFeature("a")->begin());
@@ -170,6 +173,8 @@ TEST(FeatureModelBuilder, detectXMLAlternativesBroken) {
   auto FM = B.buildFeatureModel();
   assert(FM);
 
+  ASSERT_TRUE(FeatureModelXmlParser::detectXMLAlternatives(*FM));
+
   EXPECT_TRUE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("aa")));
   EXPECT_TRUE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ab")));
 }
@@ -186,6 +191,8 @@ TEST(FeatureModelBuilder, detectXMLAlternativesOptionalBroken) {
   B.addConstraint(EXCLUDES_CONSTRAINT("ab", "aa"));
   auto FM = B.buildFeatureModel();
   assert(FM);
+
+  ASSERT_TRUE(FeatureModelXmlParser::detectXMLAlternatives(*FM));
 
   EXPECT_TRUE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("aa")));
   EXPECT_TRUE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ab")));
@@ -209,6 +216,8 @@ TEST(FeatureModelBuilder, detectXMLAlternativesOutOfOrder) {
   B.addConstraint(EXCLUDES_CONSTRAINT("ac", "ab"));
   auto FM = B.buildFeatureModel();
   assert(FM);
+
+  ASSERT_TRUE(FeatureModelXmlParser::detectXMLAlternatives(*FM));
 
   EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("aa")));
   EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ab")));

--- a/unittests/Feature/FeatureModelBuilder.cpp
+++ b/unittests/Feature/FeatureModelBuilder.cpp
@@ -128,15 +128,19 @@ TEST(FeatureModelBuilder, detectXMLAlternativesSimple) {
   B.makeFeature<BinaryFeature>("a");
   B.addEdge("a", "aa");
   B.addEdge("a", "ab");
-  auto *AA = B.makeFeature<BinaryFeature>("aa", false);
-  auto *AB = B.makeFeature<BinaryFeature>("ab", false);
+  B.makeFeature<BinaryFeature>("aa", false);
+  B.makeFeature<BinaryFeature>("ab", false);
 
   B.addConstraint(std::make_unique<ExcludesConstraint>(
-      std::make_unique<PrimaryFeatureConstraint>(AA),
-      std::make_unique<PrimaryFeatureConstraint>(AB)));
+      std::make_unique<PrimaryFeatureConstraint>(
+          std::make_unique<BinaryFeature>("aa")),
+      std::make_unique<PrimaryFeatureConstraint>(
+          std::make_unique<BinaryFeature>("ab"))));
   B.addConstraint(std::make_unique<ExcludesConstraint>(
-      std::make_unique<PrimaryFeatureConstraint>(AB),
-      std::make_unique<PrimaryFeatureConstraint>(AA)));
+      std::make_unique<PrimaryFeatureConstraint>(
+          std::make_unique<BinaryFeature>("ab")),
+      std::make_unique<PrimaryFeatureConstraint>(
+          std::make_unique<BinaryFeature>("aa"))));
   auto FM = B.buildFeatureModel();
   assert(FM);
 
@@ -157,12 +161,14 @@ TEST(FeatureModelBuilder, detectXMLAlternativesBroken) {
   B.makeFeature<BinaryFeature>("a");
   B.addEdge("a", "aa");
   B.addEdge("a", "ab");
-  auto *AA = B.makeFeature<BinaryFeature>("aa", false);
-  auto *AB = B.makeFeature<BinaryFeature>("ab", false);
+  B.makeFeature<BinaryFeature>("aa", false);
+  B.makeFeature<BinaryFeature>("ab", false);
 
   B.addConstraint(std::make_unique<ExcludesConstraint>(
-      std::make_unique<PrimaryFeatureConstraint>(AA),
-      std::make_unique<PrimaryFeatureConstraint>(AB)));
+      std::make_unique<PrimaryFeatureConstraint>(
+          std::make_unique<BinaryFeature>("aa")),
+      std::make_unique<PrimaryFeatureConstraint>(
+          std::make_unique<BinaryFeature>("ab"))));
   auto FM = B.buildFeatureModel();
   assert(FM);
 
@@ -181,15 +187,19 @@ TEST(FeatureModelBuilder, detectXMLAlternativesOutOfOrder) {
   B.makeFeature<BinaryFeature>("aa", false);
   B.makeFeature<BinaryFeature>("ac", false);
   B.makeFeature<BinaryFeature>("ae", false);
-  auto *AB = B.makeFeature<BinaryFeature>("ab", false);
-  auto *AD = B.makeFeature<BinaryFeature>("ad", false);
+  B.makeFeature<BinaryFeature>("ab", false);
+  B.makeFeature<BinaryFeature>("ad", false);
 
   B.addConstraint(std::make_unique<ExcludesConstraint>(
-      std::make_unique<PrimaryFeatureConstraint>(AB),
-      std::make_unique<PrimaryFeatureConstraint>(AD)));
+      std::make_unique<PrimaryFeatureConstraint>(
+          std::make_unique<BinaryFeature>("ab")),
+      std::make_unique<PrimaryFeatureConstraint>(
+          std::make_unique<BinaryFeature>("ad"))));
   B.addConstraint(std::make_unique<ExcludesConstraint>(
-      std::make_unique<PrimaryFeatureConstraint>(AD),
-      std::make_unique<PrimaryFeatureConstraint>(AB)));
+      std::make_unique<PrimaryFeatureConstraint>(
+          std::make_unique<BinaryFeature>("ad")),
+      std::make_unique<PrimaryFeatureConstraint>(
+          std::make_unique<BinaryFeature>("ab"))));
   auto FM = B.buildFeatureModel();
   assert(FM);
 

--- a/unittests/Feature/FeatureModelBuilder.cpp
+++ b/unittests/Feature/FeatureModelBuilder.cpp
@@ -1,4 +1,4 @@
-#include "vara/Feature/FeatureModel.h"
+#include "vara/Feature/FeatureModelBuilder.h"
 
 #include "gtest/gtest.h"
 

--- a/unittests/Feature/FeatureModelParser.cpp
+++ b/unittests/Feature/FeatureModelParser.cpp
@@ -40,4 +40,107 @@ TEST(FeatureModelParser, outOfOrder) {
   EXPECT_TRUE(P.buildFeatureModel());
 }
 
+//===----------------------------------------------------------------------===//
+//                        XMLAlternatives
+//===----------------------------------------------------------------------===//
+
+TEST(FeatureModelParser, detectXMLAlternativesSimple) {
+  FeatureModelBuilder B;
+  B.makeFeature<BinaryFeature>("a");
+  B.makeFeature<BinaryFeature>("aa", false)->addEdge("a", "aa");
+  B.makeFeature<BinaryFeature>("ab", false)->addEdge("a", "ab");
+
+  B.addConstraint(createBinaryConstraint<ExcludesConstraint>("aa", "ab"));
+  B.addConstraint(createBinaryConstraint<ExcludesConstraint>("ab", "aa"));
+  auto FM = B.buildFeatureModel();
+  ASSERT_TRUE(FM);
+
+  ASSERT_TRUE(FeatureModelXmlParser::detectXMLAlternatives(*FM));
+
+  EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("aa")));
+  EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ab")));
+  if (auto *R = llvm::dyn_cast<Relationship>(*FM->getFeature("a")->begin());
+      R) {
+    EXPECT_TRUE(R->getKind() == Relationship::RelationshipKind::RK_ALTERNATIVE);
+    EXPECT_TRUE(R->hasEdgeFrom(*FM->getFeature("a")));
+    EXPECT_TRUE(R->hasEdgeTo(*FM->getFeature("aa")));
+    EXPECT_TRUE(R->hasEdgeTo(*FM->getFeature("ab")));
+  } else {
+    FAIL();
+  }
+}
+
+TEST(FeatureModelParser, detectXMLAlternativesBroken) {
+  FeatureModelBuilder B;
+  B.makeFeature<BinaryFeature>("a");
+  B.addEdge("a", "aa");
+  B.addEdge("a", "ab");
+  B.makeFeature<BinaryFeature>("aa", false);
+  B.makeFeature<BinaryFeature>("ab", false);
+
+  B.addConstraint(createBinaryConstraint<ExcludesConstraint>("aa", "ab"));
+  auto FM = B.buildFeatureModel();
+  ASSERT_TRUE(FM);
+
+  ASSERT_TRUE(FeatureModelXmlParser::detectXMLAlternatives(*FM));
+
+  EXPECT_TRUE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("aa")));
+  EXPECT_TRUE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ab")));
+}
+
+TEST(FeatureModelParser, detectXMLAlternativesOptionalBroken) {
+  FeatureModelBuilder B;
+  B.makeFeature<BinaryFeature>("a");
+  B.addEdge("a", "aa");
+  B.addEdge("a", "ab");
+  B.makeFeature<BinaryFeature>("aa", false);
+  B.makeFeature<BinaryFeature>("ab", true);
+
+  B.addConstraint(createBinaryConstraint<ExcludesConstraint>("aa", "ab"));
+  B.addConstraint(createBinaryConstraint<ExcludesConstraint>("ab", "aa"));
+  auto FM = B.buildFeatureModel();
+  ASSERT_TRUE(FM);
+
+  ASSERT_TRUE(FeatureModelXmlParser::detectXMLAlternatives(*FM));
+
+  EXPECT_TRUE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("aa")));
+  EXPECT_TRUE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ab")));
+}
+
+TEST(FeatureModelParser, detectXMLAlternativesOutOfOrder) {
+  FeatureModelBuilder B;
+  B.makeFeature<BinaryFeature>("a");
+  B.addEdge("a", "ab");
+  B.addEdge("a", "aa");
+  B.addEdge("a", "ac");
+  B.makeFeature<BinaryFeature>("aa", false);
+  B.makeFeature<BinaryFeature>("ac", false);
+  B.makeFeature<BinaryFeature>("ab", false);
+
+  B.addConstraint(createBinaryConstraint<ExcludesConstraint>("aa", "ab"));
+  B.addConstraint(createBinaryConstraint<ExcludesConstraint>("ab", "aa"));
+  B.addConstraint(createBinaryConstraint<ExcludesConstraint>("ac", "aa"));
+  B.addConstraint(createBinaryConstraint<ExcludesConstraint>("ab", "ac"));
+  B.addConstraint(createBinaryConstraint<ExcludesConstraint>("aa", "ac"));
+  B.addConstraint(createBinaryConstraint<ExcludesConstraint>("ac", "ab"));
+  auto FM = B.buildFeatureModel();
+  ASSERT_TRUE(FM);
+
+  ASSERT_TRUE(FeatureModelXmlParser::detectXMLAlternatives(*FM));
+
+  EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("aa")));
+  EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ab")));
+  EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ac")));
+  if (auto *R = llvm::dyn_cast<Relationship>(*FM->getFeature("a")->begin());
+      R) {
+    EXPECT_TRUE(R->getKind() == Relationship::RelationshipKind::RK_ALTERNATIVE);
+    EXPECT_TRUE(R->hasEdgeFrom(*FM->getFeature("a")));
+    EXPECT_TRUE(R->hasEdgeTo(*FM->getFeature("aa")));
+    EXPECT_TRUE(R->hasEdgeTo(*FM->getFeature("ab")));
+    EXPECT_TRUE(R->hasEdgeTo(*FM->getFeature("ac")));
+  } else {
+    FAIL();
+  }
+}
+
 } // namespace vara::feature

--- a/unittests/Feature/FeatureModelTransaction.cpp
+++ b/unittests/Feature/FeatureModelTransaction.cpp
@@ -1,4 +1,5 @@
 #include "vara/Feature/FeatureModelTransaction.h"
+#include "vara/Feature/FeatureModelBuilder.h"
 
 #include "gtest/gtest.h"
 

--- a/unittests/Feature/FeatureModelTransaction.cpp
+++ b/unittests/Feature/FeatureModelTransaction.cpp
@@ -271,19 +271,13 @@ TEST_F(FeatureModelMergeTransactionTest, Idempotence) {
 }
 
 TEST_F(FeatureModelMergeTransactionTest, DifferentLocations) {
-  FeatureSourceRange::FeatureSourceLocation FSL1(2, 4);
-  FeatureSourceRange::FeatureSourceLocation FSL2(2, 30);
-  FeatureSourceRange FSR1("path", FSL1, FSL2);
+  FeatureSourceRange FSR1("path", {2, 4}, {2, 30});
   FM->getFeature("a")->addLocation(FSR1);
 
-  FeatureSourceRange::FeatureSourceLocation FSL3(10, 4);
-  FeatureSourceRange::FeatureSourceLocation FSL4(10, 30);
-  FeatureSourceRange FSR2("path", FSL3, FSL4);
+  FeatureSourceRange FSR2("path", {10, 4}, {10, 30});
   FM->getFeature("a")->addLocation(FSR2);
 
-  FeatureSourceRange::FeatureSourceLocation FSL5(12, 4);
-  FeatureSourceRange::FeatureSourceLocation FSL6(12, 30);
-  FeatureSourceRange FSR3("path", FSL5, FSL6);
+  FeatureSourceRange FSR3("path", {12, 4}, {12, 30});
   FeatureModelBuilder B;
   B.makeFeature<BinaryFeature>("a", true,
                                std::vector<FeatureSourceRange>{FSR1, FSR3});

--- a/unittests/Feature/FeatureModelTransaction.cpp
+++ b/unittests/Feature/FeatureModelTransaction.cpp
@@ -386,26 +386,30 @@ TEST_F(FeatureModelRelationshipTransactionTest, ModifyTransactionAddXorGroup) {
   // no visible changes
   {
     auto *F = FM->getFeature("a");
-    ASSERT_EQ(0, F->getChildren<Relationship>().size());
-    ASSERT_EQ(2, F->getChildren<Feature>().size());
+    EXPECT_EQ(0, F->getChildren<Relationship>().size());
+    EXPECT_EQ(2, F->getChildren<Feature>().size());
     for (auto *FChild : F->getChildren<Feature>()) {
-      ASSERT_EQ(F, FChild->getParentFeature());
+      EXPECT_EQ(F, FChild->getParentFeature());
     }
   }
 
   FT.commit();
   {
     auto *F = FM->getFeature("a");
-    ASSERT_EQ(1, F->getChildren<Relationship>().size());
+    EXPECT_EQ(1, F->getChildren<Relationship>().size());
     auto *R = *F->getChildren<Relationship>().begin();
-    ASSERT_EQ(Relationship::RelationshipKind::RK_ALTERNATIVE, R->getKind());
-    auto *RParent = llvm::dyn_cast<Feature>(R->getParent());
-    ASSERT_EQ(*F, *RParent);
+    EXPECT_EQ(Relationship::RelationshipKind::RK_ALTERNATIVE, R->getKind());
 
-    ASSERT_EQ(2, F->getChildren<Feature>().size());
-    ASSERT_EQ(2, R->getChildren<Feature>().size());
+    if (auto *RParent = llvm::dyn_cast_or_null<Feature>(R->getParent())) {
+      ASSERT_EQ(*F, *RParent);
+    } else {
+      FAIL();
+    }
+
+    EXPECT_EQ(2, F->getChildren<Feature>().size());
+    EXPECT_EQ(2, R->getChildren<Feature>().size());
     for (auto *FChild : R->getChildren<Feature>()) {
-      ASSERT_EQ(F, FChild->getParentFeature());
+      EXPECT_EQ(F, FChild->getParentFeature());
     }
   }
 }
@@ -418,36 +422,39 @@ TEST_F(FeatureModelRelationshipTransactionTest, CopyTransactionAddXorGroup) {
   // FM unchanged
   {
     auto *F = FM->getFeature("a");
-    ASSERT_EQ(0, F->getChildren<Relationship>().size());
-    ASSERT_EQ(2, F->getChildren<Feature>().size());
+    EXPECT_EQ(0, F->getChildren<Relationship>().size());
+    EXPECT_EQ(2, F->getChildren<Feature>().size());
     for (auto *FChild : F->getChildren<Feature>()) {
-      ASSERT_EQ(F, FChild->getParentFeature());
+      EXPECT_EQ(F, FChild->getParentFeature());
     }
   }
 
   auto NewFM = FT.commit();
   {
     auto *F = NewFM->getFeature("a");
-    ASSERT_EQ(1, F->getChildren<Relationship>().size());
+    EXPECT_EQ(1, F->getChildren<Relationship>().size());
     auto *R = *F->getChildren<Relationship>().begin();
-    ASSERT_EQ(Relationship::RelationshipKind::RK_ALTERNATIVE, R->getKind());
-    auto *RParent = llvm::dyn_cast<Feature>(R->getParent());
-    ASSERT_TRUE(RParent);
-    ASSERT_EQ(*F, *RParent);
+    EXPECT_EQ(Relationship::RelationshipKind::RK_ALTERNATIVE, R->getKind());
 
-    ASSERT_EQ(2, F->getChildren<Feature>().size());
-    ASSERT_EQ(2, R->getChildren<Feature>().size());
+    if (auto *RParent = llvm::dyn_cast_or_null<Feature>(R->getParent())) {
+      ASSERT_EQ(*F, *RParent);
+    } else {
+      FAIL();
+    }
+
+    EXPECT_EQ(2, F->getChildren<Feature>().size());
+    EXPECT_EQ(2, R->getChildren<Feature>().size());
     for (auto *FChild : R->getChildren<Feature>()) {
-      ASSERT_EQ(F, FChild->getParentFeature());
+      EXPECT_EQ(F, FChild->getParentFeature());
     }
   }
   // old FM still unchanged
   {
     auto *F = FM->getFeature("a");
-    ASSERT_EQ(0, F->getChildren<Relationship>().size());
-    ASSERT_EQ(2, F->getChildren<Feature>().size());
+    EXPECT_EQ(0, F->getChildren<Relationship>().size());
+    EXPECT_EQ(2, F->getChildren<Feature>().size());
     for (auto *FChild : F->getChildren<Feature>()) {
-      ASSERT_EQ(F, FChild->getParentFeature());
+      EXPECT_EQ(F, FChild->getParentFeature());
     }
   }
 }
@@ -460,36 +467,39 @@ TEST_F(FeatureModelRelationshipTransactionTest, CopyTransactionAddOrGroup) {
   // FM unchanged
   {
     auto *F = FM->getFeature("a");
-    ASSERT_EQ(0, F->getChildren<Relationship>().size());
-    ASSERT_EQ(2, F->getChildren<Feature>().size());
+    EXPECT_EQ(0, F->getChildren<Relationship>().size());
+    EXPECT_EQ(2, F->getChildren<Feature>().size());
     for (auto *FChild : F->getChildren<Feature>()) {
-      ASSERT_EQ(F, FChild->getParentFeature());
+      EXPECT_EQ(F, FChild->getParentFeature());
     }
   }
 
   auto NewFM = FT.commit();
   {
     auto *F = NewFM->getFeature("a");
-    ASSERT_EQ(1, F->getChildren<Relationship>().size());
+    EXPECT_EQ(1, F->getChildren<Relationship>().size());
     auto *R = *F->getChildren<Relationship>().begin();
-    ASSERT_EQ(Relationship::RelationshipKind::RK_OR, R->getKind());
-    auto *RParent = llvm::dyn_cast<Feature>(R->getParent());
-    ASSERT_TRUE(RParent);
-    ASSERT_EQ(*F, *RParent);
+    EXPECT_EQ(Relationship::RelationshipKind::RK_OR, R->getKind());
 
-    ASSERT_EQ(2, F->getChildren<Feature>().size());
-    ASSERT_EQ(2, R->getChildren<Feature>().size());
+    if (auto *RParent = llvm::dyn_cast_or_null<Feature>(R->getParent())) {
+      ASSERT_EQ(*F, *RParent);
+    } else {
+      FAIL();
+    }
+
+    EXPECT_EQ(2, F->getChildren<Feature>().size());
+    EXPECT_EQ(2, R->getChildren<Feature>().size());
     for (auto *FChild : R->getChildren<Feature>()) {
-      ASSERT_EQ(F, FChild->getParentFeature());
+      EXPECT_EQ(F, FChild->getParentFeature());
     }
   }
   // old FM still unchanged
   {
     auto *F = FM->getFeature("a");
-    ASSERT_EQ(0, F->getChildren<Relationship>().size());
-    ASSERT_EQ(2, F->getChildren<Feature>().size());
+    EXPECT_EQ(0, F->getChildren<Relationship>().size());
+    EXPECT_EQ(2, F->getChildren<Feature>().size());
     for (auto *FChild : F->getChildren<Feature>()) {
-      ASSERT_EQ(F, FChild->getParentFeature());
+      EXPECT_EQ(F, FChild->getParentFeature());
     }
   }
 }
@@ -502,27 +512,30 @@ TEST_F(FeatureModelRelationshipTransactionTest, ModifyTransactionAddOrGroup) {
   // FM unchanged
   {
     auto *F = FM->getFeature("a");
-    ASSERT_EQ(0, F->getChildren<Relationship>().size());
-    ASSERT_EQ(2, F->getChildren<Feature>().size());
+    EXPECT_EQ(0, F->getChildren<Relationship>().size());
+    EXPECT_EQ(2, F->getChildren<Feature>().size());
     for (auto *FChild : F->getChildren<Feature>()) {
-      ASSERT_EQ(F, FChild->getParentFeature());
+      EXPECT_EQ(F, FChild->getParentFeature());
     }
   }
 
   FT.commit();
   {
     auto *F = FM->getFeature("a");
-    ASSERT_EQ(1, F->getChildren<Relationship>().size());
+    EXPECT_EQ(1, F->getChildren<Relationship>().size());
     auto *R = *F->getChildren<Relationship>().begin();
-    ASSERT_EQ(Relationship::RelationshipKind::RK_OR, R->getKind());
-    auto *RParent = llvm::dyn_cast<Feature>(R->getParent());
-    ASSERT_TRUE(RParent);
-    ASSERT_EQ(*F, *RParent);
+    EXPECT_EQ(Relationship::RelationshipKind::RK_OR, R->getKind());
 
-    ASSERT_EQ(2, F->getChildren<Feature>().size());
-    ASSERT_EQ(2, R->getChildren<Feature>().size());
+    if (auto *RParent = llvm::dyn_cast_or_null<Feature>(R->getParent())) {
+      ASSERT_EQ(*F, *RParent);
+    } else {
+      FAIL();
+    }
+
+    EXPECT_EQ(2, F->getChildren<Feature>().size());
+    EXPECT_EQ(2, R->getChildren<Feature>().size());
     for (auto *FChild : R->getChildren<Feature>()) {
-      ASSERT_EQ(F, FChild->getParentFeature());
+      EXPECT_EQ(F, FChild->getParentFeature());
     }
   }
 }

--- a/unittests/Feature/FeatureModelTransaction.cpp
+++ b/unittests/Feature/FeatureModelTransaction.cpp
@@ -83,7 +83,7 @@ protected:
     FeatureModelBuilder B;
     B.makeFeature<BinaryFeature>("a", true);
     FM = B.buildFeatureModel();
-    assert(FM);
+    ASSERT_TRUE(FM);
   }
 
   std::unique_ptr<FeatureModel> FM;
@@ -163,7 +163,7 @@ protected:
     FeatureModelBuilder B;
     B.makeFeature<BinaryFeature>("a", true);
     FM = B.buildFeatureModel();
-    assert(FM);
+    ASSERT_TRUE(FM);
   }
 
   std::unique_ptr<FeatureModel> FM;
@@ -235,7 +235,7 @@ protected:
     FeatureModelBuilder B;
     B.makeFeature<BinaryFeature>("a", true);
     FM = B.buildFeatureModel();
-    assert(FM);
+    ASSERT_TRUE(FM);
   }
 
   std::unique_ptr<FeatureModel> FM;
@@ -372,7 +372,7 @@ protected:
     B.makeFeature<BinaryFeature>("aa", false);
     B.makeFeature<BinaryFeature>("ab", false);
     FM = B.buildFeatureModel();
-    assert(FM);
+    ASSERT_TRUE(FM);
   }
 
   std::unique_ptr<FeatureModel> FM;

--- a/unittests/Feature/FeatureModelTransaction.cpp
+++ b/unittests/Feature/FeatureModelTransaction.cpp
@@ -386,8 +386,10 @@ protected:
 
 TEST_F(FeatureModelRelationshipTransactionTest, ModifyTransactionAddXorGroup) {
   auto FT = FeatureModelModifyTransaction::openTransaction(*FM);
-  FT.addRelationship(Relationship::RelationshipKind::RK_ALTERNATIVE,
-                     FM->getFeature("a"));
+  Feature *A = FM->getFeature("a");
+  auto Children = A->getChildren<Feature>();
+  FT.addRelationship(Relationship::RelationshipKind::RK_ALTERNATIVE, A,
+                     std::set<Feature *>(Children.begin(), Children.end()));
   // no visible changes
   {
     auto *F = FM->getFeature("a");
@@ -417,8 +419,10 @@ TEST_F(FeatureModelRelationshipTransactionTest, ModifyTransactionAddXorGroup) {
 
 TEST_F(FeatureModelRelationshipTransactionTest, CopyTransactionAddXorGroup) {
   auto FT = FeatureModelCopyTransaction::openTransaction(*FM);
-  FT.addRelationship(Relationship::RelationshipKind::RK_ALTERNATIVE,
-                     FM->getFeature("a"));
+  Feature *A = FM->getFeature("a");
+  auto Children = A->getChildren<Feature>();
+  FT.addRelationship(Relationship::RelationshipKind::RK_ALTERNATIVE, A,
+                     std::set<Feature *>(Children.begin(), Children.end()));
   // FM unchanged
   {
     auto *F = FM->getFeature("a");
@@ -458,8 +462,10 @@ TEST_F(FeatureModelRelationshipTransactionTest, CopyTransactionAddXorGroup) {
 
 TEST_F(FeatureModelRelationshipTransactionTest, CopyTransactionAddOrGroup) {
   auto FT = FeatureModelCopyTransaction::openTransaction(*FM);
-  FT.addRelationship(Relationship::RelationshipKind::RK_OR,
-                     FM->getFeature("a"));
+  Feature *A = FM->getFeature("a");
+  auto Children = A->getChildren<Feature>();
+  FT.addRelationship(Relationship::RelationshipKind::RK_OR, A,
+                     std::set<Feature *>(Children.begin(), Children.end()));
   // FM unchanged
   {
     auto *F = FM->getFeature("a");
@@ -499,8 +505,10 @@ TEST_F(FeatureModelRelationshipTransactionTest, CopyTransactionAddOrGroup) {
 
 TEST_F(FeatureModelRelationshipTransactionTest, ModifyTransactionAddOrGroup) {
   auto FT = FeatureModelModifyTransaction::openTransaction(*FM);
-  FT.addRelationship(Relationship::RelationshipKind::RK_OR,
-                     FM->getFeature("a"));
+  Feature *A = FM->getFeature("a");
+  auto Children = A->getChildren<Feature>();
+  FT.addRelationship(Relationship::RelationshipKind::RK_OR, A,
+                     std::set<Feature *>(Children.begin(), Children.end()));
   // FM unchanged
   {
     auto *F = FM->getFeature("a");

--- a/unittests/Feature/FeatureModelTransaction.cpp
+++ b/unittests/Feature/FeatureModelTransaction.cpp
@@ -382,8 +382,7 @@ TEST_F(FeatureModelRelationshipTransactionTest, ModifyTransactionAddXorGroup) {
   auto FT = FeatureModelModifyTransaction::openTransaction(*FM);
   Feature *A = FM->getFeature("a");
   auto Children = A->getChildren<Feature>();
-  FT.addRelationship(Relationship::RelationshipKind::RK_ALTERNATIVE, A,
-                     std::set<Feature *>(Children.begin(), Children.end()));
+  FT.addRelationship(Relationship::RelationshipKind::RK_ALTERNATIVE, A);
   // no visible changes
   {
     auto *F = FM->getFeature("a");
@@ -415,8 +414,7 @@ TEST_F(FeatureModelRelationshipTransactionTest, CopyTransactionAddXorGroup) {
   auto FT = FeatureModelCopyTransaction::openTransaction(*FM);
   Feature *A = FM->getFeature("a");
   auto Children = A->getChildren<Feature>();
-  FT.addRelationship(Relationship::RelationshipKind::RK_ALTERNATIVE, A,
-                     std::set<Feature *>(Children.begin(), Children.end()));
+  FT.addRelationship(Relationship::RelationshipKind::RK_ALTERNATIVE, A);
   // FM unchanged
   {
     auto *F = FM->getFeature("a");
@@ -458,8 +456,7 @@ TEST_F(FeatureModelRelationshipTransactionTest, CopyTransactionAddOrGroup) {
   auto FT = FeatureModelCopyTransaction::openTransaction(*FM);
   Feature *A = FM->getFeature("a");
   auto Children = A->getChildren<Feature>();
-  FT.addRelationship(Relationship::RelationshipKind::RK_OR, A,
-                     std::set<Feature *>(Children.begin(), Children.end()));
+  FT.addRelationship(Relationship::RelationshipKind::RK_OR, A);
   // FM unchanged
   {
     auto *F = FM->getFeature("a");
@@ -501,8 +498,7 @@ TEST_F(FeatureModelRelationshipTransactionTest, ModifyTransactionAddOrGroup) {
   auto FT = FeatureModelModifyTransaction::openTransaction(*FM);
   Feature *A = FM->getFeature("a");
   auto Children = A->getChildren<Feature>();
-  FT.addRelationship(Relationship::RelationshipKind::RK_OR, A,
-                     std::set<Feature *>(Children.begin(), Children.end()));
+  FT.addRelationship(Relationship::RelationshipKind::RK_OR, A);
   // FM unchanged
   {
     auto *F = FM->getFeature("a");

--- a/unittests/Feature/FeatureModelTransaction.cpp
+++ b/unittests/Feature/FeatureModelTransaction.cpp
@@ -273,15 +273,12 @@ TEST_F(FeatureModelMergeTransactionTest, DifferentLocations) {
   FeatureSourceRange::FeatureSourceLocation FSL1(2, 4);
   FeatureSourceRange::FeatureSourceLocation FSL2(2, 30);
   FeatureSourceRange FSR1("path", FSL1, FSL2);
-  // TODO there must be a way to pass a copy directly
-  FeatureSourceRange FSRC1(FSR1);
-  FM->getFeature("a")->addLocation(FSRC1);
+  FM->getFeature("a")->addLocation(FSR1);
 
   FeatureSourceRange::FeatureSourceLocation FSL3(10, 4);
   FeatureSourceRange::FeatureSourceLocation FSL4(10, 30);
   FeatureSourceRange FSR2("path", FSL3, FSL4);
-  FeatureSourceRange FSRC2(FSR2);
-  FM->getFeature("a")->addLocation(FSRC2);
+  FM->getFeature("a")->addLocation(FSR2);
 
   FeatureSourceRange::FeatureSourceLocation FSL5(12, 4);
   FeatureSourceRange::FeatureSourceLocation FSL6(12, 30);

--- a/unittests/Feature/FeatureModelTransaction.cpp
+++ b/unittests/Feature/FeatureModelTransaction.cpp
@@ -241,8 +241,6 @@ protected:
 };
 
 TEST_F(FeatureModelMergeTransactionTest, Simple) {
-  size_t FMSizeBefore = FM->size();
-
   FeatureModelBuilder B;
   B.makeFeature<BinaryFeature>("b", true);
   auto FM2 = B.buildFeatureModel();
@@ -269,8 +267,6 @@ TEST_F(FeatureModelMergeTransactionTest, Idempotence) {
 }
 
 TEST_F(FeatureModelMergeTransactionTest, DifferentLocations) {
-  size_t FMSizeBefore = FM->size();
-
   FeatureSourceRange::FeatureSourceLocation FSL1(2, 4);
   FeatureSourceRange::FeatureSourceLocation FSL2(2, 30);
   FeatureSourceRange FSR1("path", FSL1, FSL2);
@@ -336,8 +332,6 @@ TEST_F(FeatureModelMergeTransactionTest, MultipleLevels) {
 }
 
 TEST_F(FeatureModelMergeTransactionTest, RejectDifferenceOptional) {
-  size_t FMSizeBefore = FM->size();
-
   FeatureModelBuilder B;
   B.makeFeature<BinaryFeature>("a", false);
   auto FM2 = B.buildFeatureModel();
@@ -349,8 +343,6 @@ TEST_F(FeatureModelMergeTransactionTest, RejectDifferenceOptional) {
 }
 
 TEST_F(FeatureModelMergeTransactionTest, RejectDifferenceParent) {
-  size_t FMSizeBefore = FM->size();
-
   FeatureModelBuilder B;
   B.makeFeature<BinaryFeature>("b", true);
   B.addEdge("b", "a");
@@ -364,8 +356,6 @@ TEST_F(FeatureModelMergeTransactionTest, RejectDifferenceParent) {
 }
 
 TEST_F(FeatureModelMergeTransactionTest, RejectDifferenceKind) {
-  size_t FMSizeBefore = FM->size();
-
   FeatureModelBuilder B;
   B.makeFeature<NumericFeature>("a", std::vector<int>{1, 2, 3}, true);
   auto FM2 = B.buildFeatureModel();

--- a/unittests/Feature/FeatureSourceRange.cpp
+++ b/unittests/Feature/FeatureSourceRange.cpp
@@ -59,8 +59,8 @@ TEST(FeatureSourceRange, basicAccessors) {
 }
 
 TEST(FeatureSourceRange, onlyStart) {
-  auto L = FeatureSourceRange(fs::current_path(), FeatureSourceRange::FeatureSourceLocation(1, 4)
-                              );
+  auto L = FeatureSourceRange(fs::current_path(),
+                              FeatureSourceRange::FeatureSourceLocation(1, 4));
 
   EXPECT_TRUE(L.hasStart());
   EXPECT_FALSE(L.hasEnd());
@@ -68,8 +68,7 @@ TEST(FeatureSourceRange, onlyStart) {
 
 TEST(FeatureSourceRange, onlyEnd) {
   auto L = FeatureSourceRange(fs::current_path(), std::nullopt,
-                              FeatureSourceRange::FeatureSourceLocation(3, 5)
-                              );
+                              FeatureSourceRange::FeatureSourceLocation(3, 5));
 
   EXPECT_FALSE(L.hasStart());
   EXPECT_TRUE(L.hasEnd());
@@ -77,7 +76,7 @@ TEST(FeatureSourceRange, onlyEnd) {
 
 TEST(FeatureSourceRange, equality) {
   const auto *Path1 = "path1";
-  auto Fsl1start = FeatureSourceRange::FeatureSourceLocation(1,2);
+  auto Fsl1start = FeatureSourceRange::FeatureSourceLocation(1, 2);
   auto Fsl1end = FeatureSourceRange::FeatureSourceLocation(1, 20);
   auto L1 = FeatureSourceRange(Path1, Fsl1start, Fsl1end);
   const auto *Path2 = "path2";
@@ -89,4 +88,24 @@ TEST(FeatureSourceRange, equality) {
   L2.setPath(Path1);
   EXPECT_EQ(L1, L2);
 }
+
+TEST(FeatureSourceRange, clone) {
+  auto FSR = std::make_unique<FeatureSourceRange>(
+      "path", FeatureSourceRange::FeatureSourceLocation(1, 2),
+      FeatureSourceRange::FeatureSourceLocation(3, 4),
+      FeatureSourceRange::Category::inessential);
+
+  auto Clone = FeatureSourceRange(*FSR);
+  FSR.reset();
+  // NOLINTNEXTLINE
+  EXPECT_DEATH(EXPECT_TRUE(FSR->hasStart()), ".*");
+
+  ASSERT_EQ(Clone.getPath(), "path");
+  ASSERT_EQ(Clone.getStart()->getLineNumber(), 1);
+  ASSERT_EQ(Clone.getStart()->getColumnOffset(), 2);
+  ASSERT_EQ(Clone.getEnd()->getLineNumber(), 3);
+  ASSERT_EQ(Clone.getEnd()->getColumnOffset(), 4);
+  ASSERT_EQ(Clone.getCategory(), FeatureSourceRange::Category::inessential);
+}
+
 } // namespace vara::feature

--- a/unittests/Feature/FeatureSourceRange.cpp
+++ b/unittests/Feature/FeatureSourceRange.cpp
@@ -100,12 +100,12 @@ TEST(FeatureSourceRange, clone) {
   // NOLINTNEXTLINE
   EXPECT_DEATH(EXPECT_TRUE(FSR->hasStart()), ".*");
 
-  ASSERT_EQ(Clone.getPath(), "path");
-  ASSERT_EQ(Clone.getStart()->getLineNumber(), 1);
-  ASSERT_EQ(Clone.getStart()->getColumnOffset(), 2);
-  ASSERT_EQ(Clone.getEnd()->getLineNumber(), 3);
-  ASSERT_EQ(Clone.getEnd()->getColumnOffset(), 4);
-  ASSERT_EQ(Clone.getCategory(), FeatureSourceRange::Category::inessential);
+  EXPECT_EQ(Clone.getPath(), "path");
+  EXPECT_EQ(Clone.getStart()->getLineNumber(), 1);
+  EXPECT_EQ(Clone.getStart()->getColumnOffset(), 2);
+  EXPECT_EQ(Clone.getEnd()->getLineNumber(), 3);
+  EXPECT_EQ(Clone.getEnd()->getColumnOffset(), 4);
+  EXPECT_EQ(Clone.getCategory(), FeatureSourceRange::Category::inessential);
 }
 
 } // namespace vara::feature

--- a/unittests/Feature/NumericFeature.cpp
+++ b/unittests/Feature/NumericFeature.cpp
@@ -1,5 +1,4 @@
-#include "vara/Feature/Feature.h"
-#include "vara/Feature/FeatureModel.h"
+#include "vara/Feature/FeatureModelBuilder.h"
 
 #include "llvm/Support/Casting.h"
 
@@ -43,7 +42,7 @@ TEST(NumericFeature, NumericFeatureRoot) {
   auto B = FeatureModelBuilder();
 
   B.makeFeature<NumericFeature>("F", std::pair<int, int>(0, 1));
-  B.setRootName("F");
+  B.setRoot("F");
 
   EXPECT_FALSE(B.buildFeatureModel());
 }

--- a/unittests/Feature/NumericFeature.cpp
+++ b/unittests/Feature/NumericFeature.cpp
@@ -55,7 +55,7 @@ TEST(NumericFeature, NumericFeatureChildren) {
   B.makeFeature<NumericFeature>("a", std::pair<int, int>(0, 1));
   B.addEdge("a", "aa")->makeFeature<BinaryFeature>("aa");
   auto FM = B.buildFeatureModel();
-  assert(FM);
+  ASSERT_TRUE(FM);
 
   EXPECT_EQ(
       std::distance(FM->getFeature("a")->begin(), FM->getFeature("a")->end()),

--- a/unittests/Feature/NumericFeature.cpp
+++ b/unittests/Feature/NumericFeature.cpp
@@ -42,7 +42,7 @@ TEST(NumericFeature, NumericFeatureRoot) {
   auto B = FeatureModelBuilder();
 
   B.makeFeature<NumericFeature>("F", std::pair<int, int>(0, 1));
-  B.setRoot("F");
+  B.makeRoot("F");
 
   EXPECT_FALSE(B.buildFeatureModel());
 }

--- a/unittests/Feature/NumericFeature.cpp
+++ b/unittests/Feature/NumericFeature.cpp
@@ -44,9 +44,9 @@ TEST(NumericFeature, NumericFeatureRoot) {
   B.makeFeature<NumericFeature>("F", std::pair<int, int>(0, 1));
   B.makeRoot("F");
 
-  // TODO(s9latimm): As we currently have no error handling for failing
-  //  transactions, the second modification (makeRoot) will not succeed in
-  //  changing the FM, but the build will still complete.
+  // TODO(se-passau/VaRA#744): As we currently have no error handling for
+  //  failing transactions, the second modification (makeRoot) will not succeed
+  //  in changing the FM, but the build will still complete.
   // EXPECT_FALSE(B.buildFeatureModel());
 }
 

--- a/unittests/Feature/NumericFeature.cpp
+++ b/unittests/Feature/NumericFeature.cpp
@@ -44,7 +44,10 @@ TEST(NumericFeature, NumericFeatureRoot) {
   B.makeFeature<NumericFeature>("F", std::pair<int, int>(0, 1));
   B.makeRoot("F");
 
-  EXPECT_FALSE(B.buildFeatureModel());
+  // TODO(s9latimm): As we currently have no error handling for failing
+  //  transactions, the second modification (makeRoot) will not succeed in
+  //  changing the FM, but the build will still complete.
+  // EXPECT_FALSE(B.buildFeatureModel());
 }
 
 TEST(NumericFeature, NumericFeatureChildren) {

--- a/unittests/Feature/OrderedFeatureVector.cpp
+++ b/unittests/Feature/OrderedFeatureVector.cpp
@@ -1,8 +1,9 @@
+#include "vara/Feature/OrderedFeatureVector.h"
 #include "vara/Feature/FeatureModelBuilder.h"
 
 #include "gtest/gtest.h"
 
-namespace vara::feature {
+namespace vara::feature::deprecated {
 
 class OrderedFeatureVectorTest : public ::testing::Test {
 protected:
@@ -38,7 +39,7 @@ TEST_F(OrderedFeatureVectorTest, insert) {
 
   EXPECT_EQ(OFV.size(), FM->size());
   EXPECT_EQ(Expected.size(), FM->size());
-  for (const auto *F : FM->features()) {
+  for (const auto *F : OFV) {
     EXPECT_STREQ(Expected.back()->getName().data(), F->getName().data());
     ASSERT_EQ(*Expected.back(), *F);
     Expected.pop_back();
@@ -56,7 +57,7 @@ TEST_F(OrderedFeatureVectorTest, insertFM) {
 
   EXPECT_EQ(OFV.size(), FM->size());
   EXPECT_EQ(Expected.size(), FM->size());
-  for (const auto *F : FM->features()) {
+  for (const auto *F : OFV) {
     EXPECT_STREQ(Expected.back()->getName().data(), F->getName().data());
     ASSERT_EQ(*Expected.back(), *F);
     Expected.pop_back();
@@ -77,11 +78,11 @@ TEST_F(OrderedFeatureVectorTest, insertVariadic) {
 
   EXPECT_EQ(OFV.size(), FM->size());
   EXPECT_EQ(Expected.size(), FM->size());
-  for (const auto *F : FM->features()) {
+  for (const auto *F : OFV) {
     EXPECT_STREQ(Expected.back()->getName().data(), F->getName().data());
     ASSERT_EQ(*Expected.back(), *F);
     Expected.pop_back();
   }
 }
 
-} // namespace vara::feature
+} // namespace vara::feature::deprecated

--- a/unittests/Feature/OrderedFeatureVector.cpp
+++ b/unittests/Feature/OrderedFeatureVector.cpp
@@ -39,7 +39,8 @@ TEST_F(OrderedFeatureVectorTest, insert) {
   EXPECT_EQ(OFV.size(), FM->size());
   EXPECT_EQ(Expected.size(), FM->size());
   for (const auto *F : FM->features()) {
-    EXPECT_EQ(*Expected.back(), *F);
+    EXPECT_STREQ(Expected.back()->getName().data(), F->getName().data());
+    ASSERT_EQ(*Expected.back(), *F);
     Expected.pop_back();
   }
 }
@@ -56,7 +57,8 @@ TEST_F(OrderedFeatureVectorTest, insertFM) {
   EXPECT_EQ(OFV.size(), FM->size());
   EXPECT_EQ(Expected.size(), FM->size());
   for (const auto *F : FM->features()) {
-    EXPECT_EQ(*Expected.back(), *F);
+    EXPECT_STREQ(Expected.back()->getName().data(), F->getName().data());
+    ASSERT_EQ(*Expected.back(), *F);
     Expected.pop_back();
   }
 }
@@ -76,7 +78,8 @@ TEST_F(OrderedFeatureVectorTest, insertVariadic) {
   EXPECT_EQ(OFV.size(), FM->size());
   EXPECT_EQ(Expected.size(), FM->size());
   for (const auto *F : FM->features()) {
-    EXPECT_EQ(*Expected.back(), *F);
+    EXPECT_STREQ(Expected.back()->getName().data(), F->getName().data());
+    ASSERT_EQ(*Expected.back(), *F);
     Expected.pop_back();
   }
 }

--- a/unittests/Feature/OrderedFeatureVector.cpp
+++ b/unittests/Feature/OrderedFeatureVector.cpp
@@ -16,7 +16,7 @@ protected:
     B.addEdge("b", "ba")->makeFeature<BinaryFeature>("ba");
     B.addEdge("b", "bb")->makeFeature<BinaryFeature>("bb");
     FM = B.buildFeatureModel();
-    assert(FM);
+    ASSERT_TRUE(FM);
   }
 
   std::unique_ptr<FeatureModel> FM;

--- a/unittests/Feature/OrderedFeatureVector.cpp
+++ b/unittests/Feature/OrderedFeatureVector.cpp
@@ -1,4 +1,4 @@
-#include "vara/Feature/FeatureModel.h"
+#include "vara/Feature/FeatureModelBuilder.h"
 
 #include "gtest/gtest.h"
 

--- a/unittests/Feature/Relationship.cpp
+++ b/unittests/Feature/Relationship.cpp
@@ -1,5 +1,5 @@
 #include "vara/Feature/Relationship.h"
-#include "vara/Feature/FeatureModel.h"
+#include "vara/Feature/FeatureModelBuilder.h"
 
 #include "gtest/gtest.h"
 

--- a/unittests/Feature/Relationship.cpp
+++ b/unittests/Feature/Relationship.cpp
@@ -19,7 +19,7 @@ protected:
 TEST_F(RelationshipTest, orTree) {
   B.emplaceRelationship(Relationship::RelationshipKind::RK_OR, "a");
   auto FM = B.buildFeatureModel();
-  assert(FM);
+  ASSERT_TRUE(FM);
 
   EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("aa")));
   EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ab")));
@@ -36,7 +36,7 @@ TEST_F(RelationshipTest, orTree) {
 TEST_F(RelationshipTest, alternativeTree) {
   B.emplaceRelationship(Relationship::RelationshipKind::RK_ALTERNATIVE, "a");
   auto FM = B.buildFeatureModel();
-  assert(FM);
+  ASSERT_TRUE(FM);
 
   EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("aa")));
   EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ab")));
@@ -62,7 +62,7 @@ TEST(Relationship, outOfOrder) {
 
   B.emplaceRelationship(Relationship::RelationshipKind::RK_OR, "a");
   auto FM = B.buildFeatureModel();
-  assert(FM);
+  ASSERT_TRUE(FM);
 
   EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("aa")));
   EXPECT_FALSE(FM->getFeature("a")->hasEdgeTo(*FM->getFeature("ab")));

--- a/unittests/Feature/RootFeature.cpp
+++ b/unittests/Feature/RootFeature.cpp
@@ -38,7 +38,7 @@ TEST(RootFeature, RootFeatureChildren) {
   B.addEdge("a", "aa")->makeFeature<BinaryFeature>("aa");
 
   auto FM = B.buildFeatureModel();
-  assert(FM);
+  ASSERT_TRUE(FM);
 
   EXPECT_EQ(
       std::distance(FM->getFeature("a")->begin(), FM->getFeature("a")->end()),

--- a/unittests/Feature/RootFeature.cpp
+++ b/unittests/Feature/RootFeature.cpp
@@ -24,11 +24,11 @@ TEST(RootFeature, isa) {
 TEST(RootFeature, RootFeatureRoot) {
   auto B = FeatureModelBuilder();
 
-  B.makeFeature<RootFeature>("F");
   B.setRoot("F");
   auto FM = B.buildFeatureModel();
 
   EXPECT_TRUE(FM);
+  EXPECT_TRUE(FM->getRoot());
   EXPECT_EQ("F", FM->getRoot()->getName());
 }
 
@@ -48,6 +48,19 @@ TEST(RootFeature, RootFeatureChildren) {
   } else {
     FAIL();
   }
+}
+
+TEST(RootFeature, RootFeatureChange) {
+  auto B = FeatureModelBuilder();
+
+  B.makeFeature<BinaryFeature>("A");
+  B.setRoot("F");
+  auto FM = B.buildFeatureModel();
+
+  EXPECT_TRUE(FM);
+  EXPECT_TRUE(FM->getRoot());
+  EXPECT_EQ("F", FM->getRoot()->getName());
+  EXPECT_EQ("F", FM->getFeature("A")->getParentFeature()->getName());
 }
 
 } // namespace vara::feature

--- a/unittests/Feature/RootFeature.cpp
+++ b/unittests/Feature/RootFeature.cpp
@@ -1,5 +1,4 @@
-#include "vara/Feature/Feature.h"
-#include "vara/Feature/FeatureModel.h"
+#include "vara/Feature/FeatureModelBuilder.h"
 
 #include "llvm/Support/Casting.h"
 
@@ -26,7 +25,7 @@ TEST(RootFeature, RootFeatureRoot) {
   auto B = FeatureModelBuilder();
 
   B.makeFeature<RootFeature>("F");
-  B.setRootName("F");
+  B.setRoot("F");
   auto FM = B.buildFeatureModel();
 
   EXPECT_TRUE(FM);
@@ -35,7 +34,7 @@ TEST(RootFeature, RootFeatureRoot) {
 
 TEST(RootFeature, RootFeatureChildren) {
   FeatureModelBuilder B;
-  B.setRootName("a")->makeFeature<RootFeature>("a");
+  B.setRoot("a")->makeFeature<RootFeature>("a");
   B.addEdge("a", "aa")->makeFeature<BinaryFeature>("aa");
 
   auto FM = B.buildFeatureModel();

--- a/unittests/Feature/RootFeature.cpp
+++ b/unittests/Feature/RootFeature.cpp
@@ -24,7 +24,7 @@ TEST(RootFeature, isa) {
 TEST(RootFeature, RootFeatureRoot) {
   auto B = FeatureModelBuilder();
 
-  B.setRoot("F");
+  B.makeRoot("F");
   auto FM = B.buildFeatureModel();
 
   EXPECT_TRUE(FM);
@@ -34,7 +34,7 @@ TEST(RootFeature, RootFeatureRoot) {
 
 TEST(RootFeature, RootFeatureChildren) {
   FeatureModelBuilder B;
-  B.setRoot("a")->makeFeature<RootFeature>("a");
+  B.makeRoot("a");
   B.addEdge("a", "aa")->makeFeature<BinaryFeature>("aa");
 
   auto FM = B.buildFeatureModel();
@@ -54,7 +54,7 @@ TEST(RootFeature, RootFeatureChange) {
   auto B = FeatureModelBuilder();
 
   B.makeFeature<BinaryFeature>("A");
-  B.setRoot("F");
+  B.makeRoot("F");
   auto FM = B.buildFeatureModel();
 
   EXPECT_TRUE(FM);

--- a/unittests/Feature/UnittestHelper.h
+++ b/unittests/Feature/UnittestHelper.h
@@ -9,4 +9,18 @@ inline std::string getTestResource(llvm::StringRef ResourcePath = "") {
   return (llvm::Twine(BasePath) + ResourcePath).str();
 }
 
+namespace vara::feature {
+
+template <class ConstraintTy>
+std::unique_ptr<ConstraintTy> createBinaryConstraint(const std::string &A,
+                                                     const std::string &B) {
+  return std::make_unique<ConstraintTy>(
+      std::make_unique<PrimaryFeatureConstraint>(
+          std::make_unique<BinaryFeature>(A)),
+      std::make_unique<PrimaryFeatureConstraint>(
+          std::make_unique<BinaryFeature>(B)));
+}
+
+} // namespace vara::feature
+
 #endif // UNITTEST_HELPER_H

--- a/unittests/resources/test.xml
+++ b/unittests/resources/test.xml
@@ -38,6 +38,7 @@
       <name>AA</name>
       <parent>A</parent>
       <excludedOptions>
+        <options>AB</options>
         <options>AC</options>
         <options>C</options>
       </excludedOptions>
@@ -47,6 +48,7 @@
       <name>AB</name>
       <parent>A</parent>
       <excludedOptions>
+        <options>AA</options>
         <options>AC</options>
       </excludedOptions>
       <optional>False</optional>
@@ -55,6 +57,7 @@
       <name>AC</name>
       <parent>A</parent>
       <excludedOptions>
+        <options>AA</options>
         <options>AB</options>
       </excludedOptions>
       <optional>False</optional>


### PR DESCRIPTION
Implement FMBuilder using transactions while adding required modifications.

- [x] Refactor `FeatureModelBuilder`
  - [x] move to own file
  - [x] `AddChild`
  - [x] `SetRoot`
  - [x] `SetPath`
  - [x] `SetCommit`
  - [x] `SetName`
  - [x] `AddConstraintToModel` (see se-passau/VaRA/issues/664)
  - [x] `AddRelationshipToModel` (see #44)
    - [x] tests 
- [x] Fix failing tests
- [x] Clang-Tidy

Related se-passau/VaRA/issues/744

Closes se-passau/VaRA/issues/635
Closes se-passau/VaRA/issues/669
Closes se-passau/VaRA/issues/692
Closes se-passau/VaRA/issues/724