### PR TITLE
Added MemberOffset to XML Parser

### DIFF
--- a/include/vara/Feature/FeatureSourceRange.h
+++ b/include/vara/Feature/FeatureSourceRange.h
@@ -126,7 +126,7 @@ public:
       StrS << "-" << End->toString();
     }
     if (MemberOffset) {
-      StrS << " MemberOffset: " << getMemberOffset();
+      StrS << " MemberOffset: " << &MemberOffset.value();
     }
     return StrS.str();
   }

--- a/include/vara/Feature/FeatureSourceRange.h
+++ b/include/vara/Feature/FeatureSourceRange.h
@@ -74,7 +74,7 @@ public:
                      std::optional<std::string> MemberOffset = std::nullopt,
                      Category CategoryKind = Category::necessary)
       : Path(std::move(Path)), Start(std::move(Start)), End(std::move(End)),
-        MemberOffset(std::move(MemberOffset)) CategoryKind(CategoryKind) {}
+        MemberOffset(std::move(MemberOffset)), CategoryKind(CategoryKind) {}
 
   FeatureSourceRange(fs::path Path, FeatureSourceLocation Start,
                      FeatureSourceLocation End, std::string MemberOffset,

--- a/include/vara/Feature/FeatureSourceRange.h
+++ b/include/vara/Feature/FeatureSourceRange.h
@@ -71,7 +71,7 @@ public:
   FeatureSourceRange(fs::path Path,
                      std::optional<FeatureSourceLocation> Start = std::nullopt,
                      std::optional<FeatureSourceLocation> End = std::nullopt,
-                     std::optional<std::string> MemberOffset = nullptr,
+                     std::optional<std::string> MemberOffset = std::nullopt,
                      Category CategoryKind = Category::necessary)
       : Path(std::move(Path)), Start(std::move(Start)), End(std::move(End)),
         MemberOffset(std::move(MemberOffset)), CategoryKind(CategoryKind) {}

--- a/include/vara/Feature/FeatureSourceRange.h
+++ b/include/vara/Feature/FeatureSourceRange.h
@@ -77,7 +77,8 @@ public:
         MemberOffset(std::move(MemberOffset)), CategoryKind(CategoryKind) {}
 
   FeatureSourceRange(fs::path Path, FeatureSourceLocation Start,
-                     FeatureSourceLocation End, std::string MemberOffset,
+                     FeatureSourceLocation End,
+                     std::string MemberOffset = std::nullopt,
                      Category CategoryKind = Category::necessary)
       : FeatureSourceRange(std::move(Path), std::optional(std::move(Start)),
                            std::optional(std::move(End)),

--- a/include/vara/Feature/FeatureSourceRange.h
+++ b/include/vara/Feature/FeatureSourceRange.h
@@ -72,11 +72,6 @@ public:
   public:
     FeatureMemberOffset(std::string MemberOffset)
         : MemberOffset(std::move(MemberOffset)) {}
-    FeatureMemberOffset(const FeatureMemberOffset &L) = default;
-    FeatureMemberOffset &operator=(const FeatureMemberOffset &) = default;
-    FeatureMemberOffset(FeatureMemberOffset &&) = default;
-    FeatureMemberOffset &operator=(FeatureMemberOffset &&) = default;
-    virtual ~FeatureMemberOffset() = default;
 
     void setMemberOffset(std::string MemberOffset) {
       this->MemberOffset = std::move(MemberOffset);

--- a/include/vara/Feature/FeatureSourceRange.h
+++ b/include/vara/Feature/FeatureSourceRange.h
@@ -79,7 +79,7 @@ public:
   FeatureSourceRange(fs::path Path, FeatureSourceLocation Start,
                      FeatureSourceLocation End,
                      Category CategoryKind = Category::necessary,
-                     std::string MemberOffset = std::nullopt)
+                     std::optional<std::string> MemberOffset = std::nullopt)
       : FeatureSourceRange(std::move(Path), std::optional(std::move(Start)),
                            std::optional(std::move(End)), CategoryKind,
                            std::optional(std::move(MemberOffset))) {}

--- a/include/vara/Feature/FeatureSourceRange.h
+++ b/include/vara/Feature/FeatureSourceRange.h
@@ -126,7 +126,7 @@ public:
       StrS << "-" << End->toString();
     }
     if (MemberOffset) {
-      StrS << " MemberOffset: " << MemberOffset->toString();
+      StrS << " MemberOffset: " << MemberOffset;
     }
     return StrS.str();
   }

--- a/include/vara/Feature/FeatureSourceRange.h
+++ b/include/vara/Feature/FeatureSourceRange.h
@@ -79,7 +79,7 @@ public:
   FeatureSourceRange(fs::path Path, FeatureSourceLocation Start,
                      FeatureSourceLocation End,
                      Category CategoryKind = Category::necessary,
-                     std::string MemberOffset = "")
+                     std::string MemberOffset = std::nullopt)
       : FeatureSourceRange(std::move(Path), std::optional(std::move(Start)),
                            std::optional(std::move(End)), CategoryKind,
                            std::optional(std::move(MemberOffset))) {}
@@ -115,6 +115,7 @@ public:
   [[nodiscard]] std::string *getMemberOffset() {
     return MemberOffset.has_value() ? &MemberOffset.value() : nullptr;
   }
+  void setMemberOffset(const std::string &Value) { this->MemberOffset = Value; }
 
   [[nodiscard]] std::string toString() const {
     std::stringstream StrS;

--- a/include/vara/Feature/FeatureSourceRange.h
+++ b/include/vara/Feature/FeatureSourceRange.h
@@ -77,8 +77,7 @@ public:
         MemberOffset(std::move(MemberOffset)), CategoryKind(CategoryKind) {}
 
   FeatureSourceRange(fs::path Path, FeatureSourceLocation Start,
-                     FeatureSourceLocation End,
-                     std::string MemberOffset = std::nullopt,
+                     FeatureSourceLocation End, std::string MemberOffset,
                      Category CategoryKind = Category::necessary)
       : FeatureSourceRange(std::move(Path), std::optional(std::move(Start)),
                            std::optional(std::move(End)),

--- a/include/vara/Feature/FeatureSourceRange.h
+++ b/include/vara/Feature/FeatureSourceRange.h
@@ -71,19 +71,18 @@ public:
   FeatureSourceRange(fs::path Path,
                      std::optional<FeatureSourceLocation> Start = std::nullopt,
                      std::optional<FeatureSourceLocation> End = std::nullopt,
-                     std::optional<std::string> MemberOffset = std::nullopt,
-                     Category CategoryKind = Category::necessary)
+                     Category CategoryKind = Category::necessary,
+                     std::optional<std::string> MemberOffset = std::nullopt)
       : Path(std::move(Path)), Start(std::move(Start)), End(std::move(End)),
-        MemberOffset(std::move(MemberOffset)), CategoryKind(CategoryKind) {}
+        CategoryKind(CategoryKind), MemberOffset(std::move(MemberOffset)) {}
 
   FeatureSourceRange(fs::path Path, FeatureSourceLocation Start,
                      FeatureSourceLocation End,
-                     std::string MemberOffset = std::nullopt,
-                     Category CategoryKind = Category::necessary)
+                     Category CategoryKind = Category::necessary,
+                     std::string MemberOffset = "")
       : FeatureSourceRange(std::move(Path), std::optional(std::move(Start)),
-                           std::optional(std::move(End)),
-                           std::optional(std::move(MemberOffset)),
-                           CategoryKind) {}
+                           std::optional(std::move(End)), CategoryKind,
+                           std::optional(std::move(MemberOffset))) {}
 
   FeatureSourceRange(const FeatureSourceRange &L) = default;
   FeatureSourceRange &operator=(const FeatureSourceRange &) = default;
@@ -146,8 +145,8 @@ private:
   fs::path Path;
   std::optional<FeatureSourceLocation> Start;
   std::optional<FeatureSourceLocation> End;
-  std::optional<std::string> MemberOffset;
   Category CategoryKind;
+  std::optional<std::string> MemberOffset;
 };
 } // namespace vara::feature
 

--- a/include/vara/Feature/FeatureSourceRange.h
+++ b/include/vara/Feature/FeatureSourceRange.h
@@ -112,7 +112,7 @@ public:
   [[nodiscard]] bool hasMemberOffset() const {
     return MemberOffset.has_value();
   }
-  [[nodiscard]] FeatureSourceLocation *getMemberOffset() {
+  [[nodiscard]] std::string *getMemberOffset() {
     return MemberOffset.has_value() ? &MemberOffset.value() : nullptr;
   }
 

--- a/include/vara/Feature/FeatureSourceRange.h
+++ b/include/vara/Feature/FeatureSourceRange.h
@@ -71,7 +71,7 @@ public:
   FeatureSourceRange(fs::path Path,
                      std::optional<FeatureSourceLocation> Start = std::nullopt,
                      std::optional<FeatureSourceLocation> End = std::nullopt,
-                     std::optional<std::string> MemberOffset = std::nullopt,
+                     std::optional<std::string> MemberOffset = nullptr,
                      Category CategoryKind = Category::necessary)
       : Path(std::move(Path)), Start(std::move(Start)), End(std::move(End)),
         MemberOffset(std::move(MemberOffset)), CategoryKind(CategoryKind) {}

--- a/include/vara/Feature/FeatureSourceRange.h
+++ b/include/vara/Feature/FeatureSourceRange.h
@@ -71,15 +71,18 @@ public:
   FeatureSourceRange(fs::path Path,
                      std::optional<FeatureSourceLocation> Start = std::nullopt,
                      std::optional<FeatureSourceLocation> End = std::nullopt,
+                     std::optional<std::string> MemberOffset = std::nullopt,
                      Category CategoryKind = Category::necessary)
       : Path(std::move(Path)), Start(std::move(Start)), End(std::move(End)),
-        CategoryKind(CategoryKind) {}
+        MemberOffset(std::move(MemberOffset)) CategoryKind(CategoryKind) {}
 
   FeatureSourceRange(fs::path Path, FeatureSourceLocation Start,
-                     FeatureSourceLocation End,
+                     FeatureSourceLocation End, std::string MemberOffset,
                      Category CategoryKind = Category::necessary)
       : FeatureSourceRange(std::move(Path), std::optional(std::move(Start)),
-                           std::optional(std::move(End)), CategoryKind) {}
+                           std::optional(std::move(End)),
+                           std::optional(std::move(MemberOffset)),
+                           CategoryKind) {}
 
   FeatureSourceRange(const FeatureSourceRange &L) = default;
   FeatureSourceRange &operator=(const FeatureSourceRange &) = default;
@@ -106,6 +109,13 @@ public:
     return End.has_value() ? &End.value() : nullptr;
   }
 
+  [[nodiscard]] bool hasMemberOffset() const {
+    return MemberOffset.has_value();
+  }
+  [[nodiscard]] FeatureSourceLocation *getMemberOffset() {
+    return MemberOffset.has_value() ? &MemberOffset.value() : nullptr;
+  }
+
   [[nodiscard]] std::string toString() const {
     std::stringstream StrS;
     StrS << Path.string();
@@ -115,12 +125,16 @@ public:
     if (End) {
       StrS << "-" << End->toString();
     }
+    if (MemberOffset) {
+      StrS << " MemberOffset: " << MemberOffset->toString();
+    }
     return StrS.str();
   }
 
   inline bool operator==(const FeatureSourceRange &Other) const {
     return CategoryKind == Other.CategoryKind and Path == Other.Path and
-           Start == Other.Start and End == Other.End;
+           Start == Other.Start and End == Other.End and
+           MemberOffset == Other.MemberOffset;
   }
 
   inline bool operator!=(const FeatureSourceRange &Other) const {
@@ -131,6 +145,7 @@ private:
   fs::path Path;
   std::optional<FeatureSourceLocation> Start;
   std::optional<FeatureSourceLocation> End;
+  std::optional<std::string> MemberOffset;
   Category CategoryKind;
 };
 } // namespace vara::feature

--- a/include/vara/Feature/FeatureSourceRange.h
+++ b/include/vara/Feature/FeatureSourceRange.h
@@ -68,18 +68,49 @@ public:
     unsigned Column;
   };
 
-  FeatureSourceRange(fs::path Path,
-                     std::optional<FeatureSourceLocation> Start = std::nullopt,
-                     std::optional<FeatureSourceLocation> End = std::nullopt,
-                     Category CategoryKind = Category::necessary,
-                     std::optional<std::string> MemberOffset = std::nullopt)
+  class FeatureMemberOffset {
+  public:
+    FeatureMemberOffset(std::string MemberOffset)
+        : MemberOffset(std::move(MemberOffset)) {}
+    FeatureMemberOffset(const FeatureMemberOffset &L) = default;
+    FeatureMemberOffset &operator=(const FeatureMemberOffset &) = default;
+    FeatureMemberOffset(FeatureMemberOffset &&) = default;
+    FeatureMemberOffset &operator=(FeatureMemberOffset &&) = default;
+    virtual ~FeatureMemberOffset() = default;
+
+    void setMemberOffset(std::string MemberOffset) {
+      this->MemberOffset = std::move(MemberOffset);
+    }
+    [[nodiscard]] std::string getMemberOffset() const {
+      return this->MemberOffset;
+    }
+
+    [[nodiscard]] std::string toString() const { return getMemberOffset(); }
+
+    inline bool operator==(const FeatureMemberOffset &Other) const {
+      return getMemberOffset() == Other.getMemberOffset();
+    }
+
+    inline bool operator!=(const FeatureMemberOffset &Other) const {
+      return getMemberOffset() != Other.getMemberOffset();
+    }
+
+  private:
+    std::string MemberOffset;
+  };
+
+  FeatureSourceRange(
+      fs::path Path, std::optional<FeatureSourceLocation> Start = std::nullopt,
+      std::optional<FeatureSourceLocation> End = std::nullopt,
+      Category CategoryKind = Category::necessary,
+      std::optional<FeatureMemberOffset> MemberOffset = std::nullopt)
       : Path(std::move(Path)), Start(std::move(Start)), End(std::move(End)),
         CategoryKind(CategoryKind), MemberOffset(std::move(MemberOffset)) {}
 
-  FeatureSourceRange(fs::path Path, FeatureSourceLocation Start,
-                     FeatureSourceLocation End,
-                     Category CategoryKind = Category::necessary,
-                     std::optional<std::string> MemberOffset = std::nullopt)
+  FeatureSourceRange(
+      fs::path Path, FeatureSourceLocation Start, FeatureSourceLocation End,
+      Category CategoryKind = Category::necessary,
+      std::optional<FeatureMemberOffset> MemberOffset = std::nullopt)
       : FeatureSourceRange(std::move(Path), std::optional(std::move(Start)),
                            std::optional(std::move(End)), CategoryKind,
                            std::optional(std::move(MemberOffset))) {}
@@ -112,10 +143,9 @@ public:
   [[nodiscard]] bool hasMemberOffset() const {
     return MemberOffset.has_value();
   }
-  [[nodiscard]] std::string *getMemberOffset() {
+  [[nodiscard]] FeatureMemberOffset *getMemberOffset() {
     return MemberOffset.has_value() ? &MemberOffset.value() : nullptr;
   }
-  void setMemberOffset(const std::string &Value) { this->MemberOffset = Value; }
 
   [[nodiscard]] std::string toString() const {
     std::stringstream StrS;
@@ -127,7 +157,7 @@ public:
       StrS << "-" << End->toString();
     }
     if (MemberOffset) {
-      StrS << " MemberOffset: " << &MemberOffset.value();
+      StrS << " MemberOffset: " << MemberOffset->toString();
     }
     return StrS.str();
   }
@@ -147,7 +177,7 @@ private:
   std::optional<FeatureSourceLocation> Start;
   std::optional<FeatureSourceLocation> End;
   Category CategoryKind;
-  std::optional<std::string> MemberOffset;
+  std::optional<FeatureMemberOffset> MemberOffset;
 };
 } // namespace vara::feature
 

--- a/include/vara/Feature/FeatureSourceRange.h
+++ b/include/vara/Feature/FeatureSourceRange.h
@@ -126,7 +126,7 @@ public:
       StrS << "-" << End->toString();
     }
     if (MemberOffset) {
-      StrS << " MemberOffset: " << MemberOffset;
+      StrS << " MemberOffset: " << getMemberOffset();
     }
     return StrS.str();
   }

--- a/lib/Feature/FeatureModelParser.cpp
+++ b/lib/Feature/FeatureModelParser.cpp
@@ -129,7 +129,6 @@ FeatureModelXmlParser::createFeatureSourceRange(xmlNode *Head) {
   std::optional<FeatureSourceRange::FeatureSourceLocation> Start;
   std::optional<FeatureSourceRange::FeatureSourceLocation> End;
   std::optional<std::string> MemberOffset;
-  xmlChar Member;
   enum FeatureSourceRange::Category Category;
 
   std::unique_ptr<xmlChar, void (*)(void *)> Tmp(

--- a/lib/Feature/FeatureModelParser.cpp
+++ b/lib/Feature/FeatureModelParser.cpp
@@ -128,6 +128,8 @@ FeatureModelXmlParser::createFeatureSourceRange(xmlNode *Head) {
   fs::path Path;
   std::optional<FeatureSourceRange::FeatureSourceLocation> Start;
   std::optional<FeatureSourceRange::FeatureSourceLocation> End;
+  std::optional<std::string> MemberOffset;
+  xmlChar Member;
   enum FeatureSourceRange::Category Category;
 
   std::unique_ptr<xmlChar, void (*)(void *)> Tmp(
@@ -156,10 +158,13 @@ FeatureModelXmlParser::createFeatureSourceRange(xmlNode *Head) {
         Start = createFeatureSourceLocation(Child);
       } else if (!xmlStrcmp(Child->name, XmlConstants::END)) {
         End = createFeatureSourceLocation(Child);
+      } else if (!xmlStrcmp(Child->name, XmlConstants::MEMBEROFFSET)) {
+        MemberOffset =
+            std::string(reinterpret_cast<char *>(xmlNodeGetContent(Child)));
       }
     }
   }
-  return {Path, Start, End, Category};
+  return {Path, Start, End, MemberOffset, Category};
 }
 
 Result<FTErrorCode> FeatureModelXmlParser::parseOptions(xmlNode *Node,

--- a/lib/Feature/FeatureModelParser.cpp
+++ b/lib/Feature/FeatureModelParser.cpp
@@ -128,8 +128,8 @@ FeatureModelXmlParser::createFeatureSourceRange(xmlNode *Head) {
   fs::path Path;
   std::optional<FeatureSourceRange::FeatureSourceLocation> Start;
   std::optional<FeatureSourceRange::FeatureSourceLocation> End;
-  std::optional<std::string> MemberOffset;
   enum FeatureSourceRange::Category Category;
+  std::optional<std::string> MemberOffset;
 
   std::unique_ptr<xmlChar, void (*)(void *)> Tmp(
       xmlGetProp(Head, XmlConstants::CATEGORY), xmlFree);
@@ -163,7 +163,7 @@ FeatureModelXmlParser::createFeatureSourceRange(xmlNode *Head) {
       }
     }
   }
-  return {Path, Start, End, MemberOffset, Category};
+  return {Path, Start, End, Category, MemberOffset};
 }
 
 Result<FTErrorCode> FeatureModelXmlParser::parseOptions(xmlNode *Node,

--- a/lib/Feature/XmlConstants.h
+++ b/lib/Feature/XmlConstants.h
@@ -25,6 +25,7 @@ public:
   static constexpr xmlChar OPTIONS[] = "options";
   static constexpr xmlChar LOCATIONS[] = "locations";
   static constexpr xmlChar SOURCERANGE[] = "sourceRange";
+  static constexpr xmlChar MEMBEROFFSET[] = "memberOffset";
   static constexpr xmlChar PATH[] = "path";
   static constexpr xmlChar START[] = "start";
   static constexpr xmlChar END[] = "end";
@@ -48,7 +49,8 @@ public:
   static inline const std::string DtdRaw =
       "<!ELEMENT vm (binaryOptions, numericOptions?, booleanConstraints?, "
       "nonBooleanConstraints?, mixedConstraints?)>\n"
-      "<!ATTLIST vm name CDATA #REQUIRED root CDATA #IMPLIED commit CDATA #IMPLIED>\n"
+      "<!ATTLIST vm name CDATA #REQUIRED root CDATA #IMPLIED commit CDATA "
+      "#IMPLIED>\n"
       "<!ELEMENT binaryOptions (configurationOption*)>\n"
       "<!ELEMENT numericOptions (configurationOption*)>\n"
       "<!ELEMENT booleanConstraints (constraint*)>\n"
@@ -79,7 +81,7 @@ public:
       "<!ELEMENT values (#PCDATA)>\n"
       "<!ELEMENT stepFunction (#PCDATA)>\n"
       "<!ELEMENT locations (sourceRange*)>\n"
-      "<!ELEMENT sourceRange (path, start, end)>\n"
+      "<!ELEMENT sourceRange (path, start, end, memberOffset?)>\n"
       "<!ATTLIST sourceRange category (necessary|inessential) \"necessary\">\n"
       "<!ELEMENT path (#PCDATA)>\n"
       "<!ELEMENT start (line, column)>\n"

--- a/unittests/Feature/FeatureModelTransaction.cpp
+++ b/unittests/Feature/FeatureModelTransaction.cpp
@@ -270,13 +270,13 @@ TEST_F(FeatureModelMergeTransactionTest, Idempotence) {
 }
 
 TEST_F(FeatureModelMergeTransactionTest, DifferentLocations) {
-  FeatureSourceRange FSR1("path", {2, 4}, {2, 30}, nullptr);
+  FeatureSourceRange FSR1("path", {2, 4}, {2, 30});
   FM->getFeature("a")->addLocation(FSR1);
 
-  FeatureSourceRange FSR2("path", {10, 4}, {10, 30}, nullptr);
+  FeatureSourceRange FSR2("path", {10, 4}, {10, 30});
   FM->getFeature("a")->addLocation(FSR2);
 
-  FeatureSourceRange FSR3("path", {12, 4}, {12, 30}, nullptr);
+  FeatureSourceRange FSR3("path", {12, 4}, {12, 30});
   FeatureModelBuilder B;
   B.makeFeature<BinaryFeature>("a", true,
                                std::vector<FeatureSourceRange>{FSR1, FSR3});
@@ -696,13 +696,13 @@ protected:
     B->addLocation(FSRInitial);
   }
 
-  FeatureSourceRange FSRInitial{"path", {2, 4}, {2, 10}, nullptr};
+  FeatureSourceRange FSRInitial{"path", {2, 4}, {2, 10}};
   std::unique_ptr<FeatureModel> FM;
 };
 
 TEST_F(FeatureModelLocationsTransactionTest, CopyTransactionAddLocation) {
-  FeatureSourceRange FSRA("path", {2, 4}, {2, 10}, nullptr);
-  FeatureSourceRange FSRB("path", {5, 4}, {5, 10}, nullptr);
+  FeatureSourceRange FSRA("path", {2, 4}, {2, 10});
+  FeatureSourceRange FSRB("path", {5, 4}, {5, 10});
 
   auto FT = FeatureModelCopyTransaction::openTransaction(*FM);
   auto VA = detail::FeatureVariantTy(FM->getFeature("a"));
@@ -741,8 +741,8 @@ TEST_F(FeatureModelLocationsTransactionTest, CopyTransactionRemoveLocation) {
 }
 
 TEST_F(FeatureModelLocationsTransactionTest, ModifyTransactionAddLocation) {
-  FeatureSourceRange FSRA("path", {2, 4}, {2, 10}, nullptr);
-  FeatureSourceRange FSRB("path", {5, 4}, {5, 10}, nullptr);
+  FeatureSourceRange FSRA("path", {2, 4}, {2, 10});
+  FeatureSourceRange FSRB("path", {5, 4}, {5, 10});
 
   auto FT = FeatureModelModifyTransaction::openTransaction(*FM);
   auto VA = detail::FeatureVariantTy(FM->getFeature("a"));

--- a/unittests/Feature/FeatureModelTransaction.cpp
+++ b/unittests/Feature/FeatureModelTransaction.cpp
@@ -701,8 +701,8 @@ protected:
 };
 
 TEST_F(FeatureModelLocationsTransactionTest, CopyTransactionAddLocation) {
-  FeatureSourceRange FSRA("path", {2, 4}, {2, 10});
-  FeatureSourceRange FSRB("path", {5, 4}, {5, 10});
+  FeatureSourceRange FSRA("path", {2, 4}, {2, 10}, nullptr);
+  FeatureSourceRange FSRB("path", {5, 4}, {5, 10}, nullptr);
 
   auto FT = FeatureModelCopyTransaction::openTransaction(*FM);
   auto VA = detail::FeatureVariantTy(FM->getFeature("a"));
@@ -741,8 +741,8 @@ TEST_F(FeatureModelLocationsTransactionTest, CopyTransactionRemoveLocation) {
 }
 
 TEST_F(FeatureModelLocationsTransactionTest, ModifyTransactionAddLocation) {
-  FeatureSourceRange FSRA("path", {2, 4}, {2, 10});
-  FeatureSourceRange FSRB("path", {5, 4}, {5, 10});
+  FeatureSourceRange FSRA("path", {2, 4}, {2, 10}, nullptr);
+  FeatureSourceRange FSRB("path", {5, 4}, {5, 10}, nullptr);
 
   auto FT = FeatureModelModifyTransaction::openTransaction(*FM);
   auto VA = detail::FeatureVariantTy(FM->getFeature("a"));

--- a/unittests/Feature/FeatureModelTransaction.cpp
+++ b/unittests/Feature/FeatureModelTransaction.cpp
@@ -270,13 +270,13 @@ TEST_F(FeatureModelMergeTransactionTest, Idempotence) {
 }
 
 TEST_F(FeatureModelMergeTransactionTest, DifferentLocations) {
-  FeatureSourceRange FSR1("path", {2, 4}, {2, 30});
+  FeatureSourceRange FSR1("path", {2, 4}, {2, 30}, nullptr);
   FM->getFeature("a")->addLocation(FSR1);
 
-  FeatureSourceRange FSR2("path", {10, 4}, {10, 30});
+  FeatureSourceRange FSR2("path", {10, 4}, {10, 30}, nullptr);
   FM->getFeature("a")->addLocation(FSR2);
 
-  FeatureSourceRange FSR3("path", {12, 4}, {12, 30});
+  FeatureSourceRange FSR3("path", {12, 4}, {12, 30}, nullptr);
   FeatureModelBuilder B;
   B.makeFeature<BinaryFeature>("a", true,
                                std::vector<FeatureSourceRange>{FSR1, FSR3});
@@ -696,7 +696,7 @@ protected:
     B->addLocation(FSRInitial);
   }
 
-  FeatureSourceRange FSRInitial{"path", {2, 4}, {2, 10}};
+  FeatureSourceRange FSRInitial{"path", {2, 4}, {2, 10}, nullptr};
   std::unique_ptr<FeatureModel> FM;
 };
 

--- a/unittests/Feature/FeatureSourceRange.cpp
+++ b/unittests/Feature/FeatureSourceRange.cpp
@@ -90,10 +90,10 @@ TEST(FeatureSourceRange, equality) {
 }
 
 TEST(FeatureSourceRange, clone) {
-  auto FSR = std::make_unique<FeatureSourceRange>(
+  auto FSR = std::make_unique<FeatureSourceRange>(FeatureSourceRange(
       "path", FeatureSourceRange::FeatureSourceLocation(1, 2),
-      FeatureSourceRange::FeatureSourceLocation(3, 4), nullptr,
-      FeatureSourceRange::Category::inessential);
+      FeatureSourceRange::FeatureSourceLocation(3, 4),
+      FeatureSourceRange::Category::inessential));
 
   auto Clone = FeatureSourceRange(*FSR);
   FSR.reset();

--- a/unittests/Feature/FeatureSourceRange.cpp
+++ b/unittests/Feature/FeatureSourceRange.cpp
@@ -12,10 +12,11 @@ TEST(FeatureSourceRange, comparison) {
 }
 
 TEST(FeatureSourceRange, full) {
+  const auto MemberOffset = "memberOffset";
   auto L = FeatureSourceRange(
       fs::current_path(), FeatureSourceRange::FeatureSourceLocation(1, 4),
       FeatureSourceRange::FeatureSourceLocation(3, 5),
-      FeatureSourceRange::Category::inessential, "memberOffset");
+      FeatureSourceRange::Category::inessential, MemberOffset);
 
   EXPECT_EQ(L.getPath(), fs::current_path());
   EXPECT_EQ(L.getStart()->getLineNumber(), 1);
@@ -23,7 +24,7 @@ TEST(FeatureSourceRange, full) {
   EXPECT_EQ(L.getEnd()->getLineNumber(), 3);
   EXPECT_EQ(L.getEnd()->getColumnOffset(), 5);
   EXPECT_EQ(L.getCategory(), FeatureSourceRange::Category::inessential);
-  EXPECT_EQ(L.getMemberOffset(), "memberOffset");
+  EXPECT_EQ(L.getMemberOffset(), MemberOffset);
 }
 
 TEST(FeatureSourceLocation, basicAccessors) {

--- a/unittests/Feature/FeatureSourceRange.cpp
+++ b/unittests/Feature/FeatureSourceRange.cpp
@@ -15,7 +15,8 @@ TEST(FeatureSourceRange, full) {
   auto L = FeatureSourceRange(
       fs::current_path(), FeatureSourceRange::FeatureSourceLocation(1, 4),
       FeatureSourceRange::FeatureSourceLocation(3, 5),
-      FeatureSourceRange::Category::inessential, "memberOffset");
+      FeatureSourceRange::Category::inessential,
+      FeatureSourceRange::FeatureMemberOffset("memberOffset"));
 
   EXPECT_EQ(L.getPath(), fs::current_path());
   EXPECT_EQ(L.getStart()->getLineNumber(), 1);
@@ -23,7 +24,22 @@ TEST(FeatureSourceRange, full) {
   EXPECT_EQ(L.getEnd()->getLineNumber(), 3);
   EXPECT_EQ(L.getEnd()->getColumnOffset(), 5);
   EXPECT_EQ(L.getCategory(), FeatureSourceRange::Category::inessential);
-  EXPECT_EQ(L.getMemberOffset()->compare("memberOffset"), 0);
+  EXPECT_EQ(L.getMemberOffset()->toString().compare("memberOffset"), 0);
+}
+
+TEST(FeatureSourceRange, noMemberOffset) {
+  auto L = FeatureSourceRange(fs::current_path(),
+                              FeatureSourceRange::FeatureSourceLocation(1, 4),
+                              FeatureSourceRange::FeatureSourceLocation(3, 5),
+                              FeatureSourceRange::Category::inessential);
+
+  EXPECT_EQ(L.getPath(), fs::current_path());
+  EXPECT_EQ(L.getStart()->getLineNumber(), 1);
+  EXPECT_EQ(L.getStart()->getColumnOffset(), 4);
+  EXPECT_EQ(L.getEnd()->getLineNumber(), 3);
+  EXPECT_EQ(L.getEnd()->getColumnOffset(), 5);
+  EXPECT_EQ(L.getCategory(), FeatureSourceRange::Category::inessential);
+  EXPECT_EQ(L.getMemberOffset(), nullptr);
 }
 
 TEST(FeatureSourceLocation, basicAccessors) {
@@ -47,6 +63,32 @@ TEST(FeatureSourceLocation, comparison) {
   auto OtherLCO = FeatureSourceRange::FeatureSourceLocation(3, 4);
 
   EXPECT_EQ(SelfLCO, OtherLCO);
+}
+
+TEST(FeatureMemberOffset, basicAccessor) {
+  auto Member = FeatureSourceRange::FeatureMemberOffset("member");
+
+  EXPECT_EQ(Member.getMemberOffset().compare("member"), 0);
+}
+
+TEST(FeatureMemberOffset, basicSetter) {
+  auto Member = FeatureSourceRange::FeatureMemberOffset("member");
+  Member.setMemberOffset("setMemberOffset");
+
+  EXPECT_EQ(Member.getMemberOffset().compare("setMemberOffset"), 0);
+}
+
+TEST(FeatureMemberOffset, comparison) {
+  const std::string MemString1 = "member1";
+  const std::string MemString2 = "member2";
+  auto Member1 = FeatureSourceRange::FeatureMemberOffset(MemString1);
+  auto Member2 = FeatureSourceRange::FeatureMemberOffset(MemString2);
+
+  EXPECT_NE(Member1, Member2);
+
+  Member2.setMemberOffset(MemString1);
+
+  EXPECT_EQ(Member1, Member2);
 }
 
 TEST(FeatureSourceRange, basicAccessors) {
@@ -79,14 +121,16 @@ TEST(FeatureSourceRange, onlyEnd) {
 
 TEST(FeatureSourceRange, equality) {
   const auto *Path1 = "path1";
-  const auto *MemberOffset1 = "memberOffset1";
+  const auto MemberOffset1 =
+      FeatureSourceRange::FeatureMemberOffset("memberOffset1");
   auto Fsl1start = FeatureSourceRange::FeatureSourceLocation(1, 2);
   auto Fsl1end = FeatureSourceRange::FeatureSourceLocation(1, 20);
   auto L1 = FeatureSourceRange(Path1, Fsl1start, Fsl1end,
                                FeatureSourceRange::Category::inessential,
                                MemberOffset1);
   const auto *Path2 = "path2";
-  const auto *MemberOffset2 = "memberOffset2";
+  const auto MemberOffset2 =
+      FeatureSourceRange::FeatureMemberOffset("memberOffset2");
   auto Fsl2start = FeatureSourceRange::FeatureSourceLocation(1, 2);
   auto Fsl2end = FeatureSourceRange::FeatureSourceLocation(1, 20);
   auto L2 = FeatureSourceRange(Path2, Fsl2start, Fsl2end,
@@ -97,7 +141,7 @@ TEST(FeatureSourceRange, equality) {
   L2.setPath(Path1);
   EXPECT_NE(L1, L2);
 
-  L2.setMemberOffset(MemberOffset1);
+  L2.getMemberOffset()->setMemberOffset("memberOffset1");
   EXPECT_EQ(L1, L2);
 }
 
@@ -105,7 +149,8 @@ TEST(FeatureSourceRange, clone) {
   auto FSR = std::make_unique<FeatureSourceRange>(
       "path", FeatureSourceRange::FeatureSourceLocation(1, 2),
       FeatureSourceRange::FeatureSourceLocation(3, 4),
-      FeatureSourceRange::Category::inessential, "memberOffset");
+      FeatureSourceRange::Category::inessential,
+      FeatureSourceRange::FeatureMemberOffset("memberOffset"));
 
   auto Clone = FeatureSourceRange(*FSR);
   FSR.reset();
@@ -117,7 +162,7 @@ TEST(FeatureSourceRange, clone) {
   EXPECT_EQ(Clone.getStart()->getColumnOffset(), 2);
   EXPECT_EQ(Clone.getEnd()->getLineNumber(), 3);
   EXPECT_EQ(Clone.getEnd()->getColumnOffset(), 4);
-  EXPECT_EQ(Clone.getMemberOffset()->compare("memberOffset"), 0);
+  EXPECT_EQ(Clone.getMemberOffset()->toString().compare("memberOffset"), 0);
   EXPECT_EQ(Clone.getCategory(), FeatureSourceRange::Category::inessential);
 }
 

--- a/unittests/Feature/FeatureSourceRange.cpp
+++ b/unittests/Feature/FeatureSourceRange.cpp
@@ -12,11 +12,10 @@ TEST(FeatureSourceRange, comparison) {
 }
 
 TEST(FeatureSourceRange, full) {
-  const auto MemberOffset = "memberOffset";
   auto L = FeatureSourceRange(
       fs::current_path(), FeatureSourceRange::FeatureSourceLocation(1, 4),
       FeatureSourceRange::FeatureSourceLocation(3, 5),
-      FeatureSourceRange::Category::inessential, MemberOffset);
+      FeatureSourceRange::Category::inessential, "memberOffset");
 
   EXPECT_EQ(L.getPath(), fs::current_path());
   EXPECT_EQ(L.getStart()->getLineNumber(), 1);
@@ -24,7 +23,7 @@ TEST(FeatureSourceRange, full) {
   EXPECT_EQ(L.getEnd()->getLineNumber(), 3);
   EXPECT_EQ(L.getEnd()->getColumnOffset(), 5);
   EXPECT_EQ(L.getCategory(), FeatureSourceRange::Category::inessential);
-  EXPECT_EQ(L.getMemberOffset(), MemberOffset);
+  EXPECT_EQ(L.getMemberOffset()->compare("memberOffset"), 0);
 }
 
 TEST(FeatureSourceLocation, basicAccessors) {
@@ -80,15 +79,19 @@ TEST(FeatureSourceRange, onlyEnd) {
 
 TEST(FeatureSourceRange, equality) {
   const auto *Path1 = "path1";
+  const auto *MemberOffset1 = "memberOffset1";
   auto Fsl1start = FeatureSourceRange::FeatureSourceLocation(1, 2);
   auto Fsl1end = FeatureSourceRange::FeatureSourceLocation(1, 20);
-  auto L1 = FeatureSourceRange(Path1, Fsl1start, Fsl1end);
-  const auto MemberOffset1 = "memberOffset1";
+  auto L1 = FeatureSourceRange(Path1, Fsl1start, Fsl1end,
+                               FeatureSourceRange::Category::inessential,
+                               MemberOffset1);
   const auto *Path2 = "path2";
+  const auto *MemberOffset2 = "memberOffset2";
   auto Fsl2start = FeatureSourceRange::FeatureSourceLocation(1, 2);
   auto Fsl2end = FeatureSourceRange::FeatureSourceLocation(1, 20);
-  auto L2 = FeatureSourceRange(Path2, Fsl2start, Fsl2end);
-  const auto MemberOffset2 = "memberOffset2";
+  auto L2 = FeatureSourceRange(Path2, Fsl2start, Fsl2end,
+                               FeatureSourceRange::Category::inessential,
+                               MemberOffset2);
   EXPECT_NE(L1, L2);
 
   L2.setPath(Path1);
@@ -101,8 +104,8 @@ TEST(FeatureSourceRange, equality) {
 TEST(FeatureSourceRange, clone) {
   auto FSR = std::make_unique<FeatureSourceRange>(
       "path", FeatureSourceRange::FeatureSourceLocation(1, 2),
-      FeatureSourceRange::FeatureSourceLocation(3, 4), "memberOffset",
-      FeatureSourceRange::Category::inessential);
+      FeatureSourceRange::FeatureSourceLocation(3, 4),
+      FeatureSourceRange::Category::inessential, "memberOffset");
 
   auto Clone = FeatureSourceRange(*FSR);
   FSR.reset();
@@ -114,7 +117,7 @@ TEST(FeatureSourceRange, clone) {
   EXPECT_EQ(Clone.getStart()->getColumnOffset(), 2);
   EXPECT_EQ(Clone.getEnd()->getLineNumber(), 3);
   EXPECT_EQ(Clone.getEnd()->getColumnOffset(), 4);
-  EXPECT_EQ(Clone.getMemberOffset(), "memberOffset");
+  EXPECT_EQ(Clone.getMemberOffset()->compare("memberOffset"), 0);
   EXPECT_EQ(Clone.getCategory(), FeatureSourceRange::Category::inessential);
 }
 

--- a/unittests/Feature/FeatureSourceRange.cpp
+++ b/unittests/Feature/FeatureSourceRange.cpp
@@ -92,7 +92,7 @@ TEST(FeatureSourceRange, equality) {
 TEST(FeatureSourceRange, clone) {
   auto FSR = std::make_unique<FeatureSourceRange>(
       "path", FeatureSourceRange::FeatureSourceLocation(1, 2),
-      FeatureSourceRange::FeatureSourceLocation(3, 4),
+      FeatureSourceRange::FeatureSourceLocation(3, 4), nullptr,
       FeatureSourceRange::Category::inessential);
 
   auto Clone = FeatureSourceRange(*FSR);

--- a/unittests/Feature/FeatureSourceRange.cpp
+++ b/unittests/Feature/FeatureSourceRange.cpp
@@ -12,15 +12,18 @@ TEST(FeatureSourceRange, comparison) {
 }
 
 TEST(FeatureSourceRange, full) {
-  auto L = FeatureSourceRange(fs::current_path(),
-                              FeatureSourceRange::FeatureSourceLocation(1, 4),
-                              FeatureSourceRange::FeatureSourceLocation(3, 5));
+  auto L = FeatureSourceRange(
+      fs::current_path(), FeatureSourceRange::FeatureSourceLocation(1, 4),
+      FeatureSourceRange::FeatureSourceLocation(3, 5),
+      FeatureSourceRange::Category::inessential, "memberOffset");
 
   EXPECT_EQ(L.getPath(), fs::current_path());
   EXPECT_EQ(L.getStart()->getLineNumber(), 1);
   EXPECT_EQ(L.getStart()->getColumnOffset(), 4);
   EXPECT_EQ(L.getEnd()->getLineNumber(), 3);
   EXPECT_EQ(L.getEnd()->getColumnOffset(), 5);
+  EXPECT_EQ(L.getCategory(), FeatureSourceRange::Category::inessential);
+  EXPECT_EQ(L.getMemberOffset(), "memberOffset");
 }
 
 TEST(FeatureSourceLocation, basicAccessors) {
@@ -79,21 +82,26 @@ TEST(FeatureSourceRange, equality) {
   auto Fsl1start = FeatureSourceRange::FeatureSourceLocation(1, 2);
   auto Fsl1end = FeatureSourceRange::FeatureSourceLocation(1, 20);
   auto L1 = FeatureSourceRange(Path1, Fsl1start, Fsl1end);
+  const auto MemberOffset1 = "memberOffset1";
   const auto *Path2 = "path2";
   auto Fsl2start = FeatureSourceRange::FeatureSourceLocation(1, 2);
   auto Fsl2end = FeatureSourceRange::FeatureSourceLocation(1, 20);
   auto L2 = FeatureSourceRange(Path2, Fsl2start, Fsl2end);
+  const auto MemberOffset2 = "memberOffset2";
   EXPECT_NE(L1, L2);
 
   L2.setPath(Path1);
+  EXPECT_NE(L1, L2);
+
+  L2.setMemberOffset(MemberOffset1);
   EXPECT_EQ(L1, L2);
 }
 
 TEST(FeatureSourceRange, clone) {
-  auto FSR = std::make_unique<FeatureSourceRange>(FeatureSourceRange(
+  auto FSR = std::make_unique<FeatureSourceRange>(
       "path", FeatureSourceRange::FeatureSourceLocation(1, 2),
-      FeatureSourceRange::FeatureSourceLocation(3, 4),
-      FeatureSourceRange::Category::inessential));
+      FeatureSourceRange::FeatureSourceLocation(3, 4), "memberOffset",
+      FeatureSourceRange::Category::inessential);
 
   auto Clone = FeatureSourceRange(*FSR);
   FSR.reset();
@@ -105,6 +113,7 @@ TEST(FeatureSourceRange, clone) {
   EXPECT_EQ(Clone.getStart()->getColumnOffset(), 2);
   EXPECT_EQ(Clone.getEnd()->getLineNumber(), 3);
   EXPECT_EQ(Clone.getEnd()->getColumnOffset(), 4);
+  EXPECT_EQ(Clone.getMemberOffset(), "memberOffset");
   EXPECT_EQ(Clone.getCategory(), FeatureSourceRange::Category::inessential);
 }
 


### PR DESCRIPTION
Defined XMLConstant MemberOffset in SourceRange
Extended FeatureModelParser to extract MemberOffset as std::string
Extended FeatureSourceRange with std::string MemberOffset

Need feedback particularly on:
- the type conversion xmlChar* to std::string.
- the use of std::string for the MemberOffset, is that what we want?

related se-sic/VaRA#823