### PR TITLE
Fixes unittest to correctly run on the LLVM side

### DIFF
--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -6,6 +6,9 @@ set(VARA_FEATURE_LIBS
   VaRAFeature
   VaRAConfiguration
 )
+set(VARA_FEAUTRE_TEST_WORKING_DIR
+  ${CMAKE_CURRENT_BINARY_DIR}
+)
 
 foreach(TEST_UNIT ${VARA_FEATURE_TEST_UNITS})
   message(STATUS "Setting: ${TEST_UNIT}")
@@ -56,7 +59,7 @@ function(add_vara_unittest test_name)
     add_test(
       NAME "${test_name}"
       COMMAND ${test_name} ${CATCH_TEST_FILTER}
-      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+      WORKING_DIRECTORY ${VARA_FEAUTRE_TEST_WORKING_DIR}
     )
     set(CTEST_OUTPUT_ON_FAILURE 1)
   endif()

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -56,6 +56,7 @@ function(add_vara_unittest test_name)
     add_test(
       NAME "${test_name}"
       COMMAND ${test_name} ${CATCH_TEST_FILTER}
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
     set(CTEST_OUTPUT_ON_FAILURE 1)
   endif()

--- a/unittests/Feature/UnittestHelper.h
+++ b/unittests/Feature/UnittestHelper.h
@@ -5,7 +5,7 @@
 #include "llvm/ADT/Twine.h"
 
 inline std::string getTestResource(llvm::StringRef ResourcePath = "") {
-  constexpr const char *BasePath = "../resources/";
+  constexpr const char *BasePath = "resources/";
   return (llvm::Twine(BasePath) + ResourcePath).str();
 }
 


### PR DESCRIPTION
Sets the test execution directory for tests to a fixed location, so tests are executed in the same directory when run in-tree as well as out-of-tree.