### PR TITLE
Refactors llvm::Optional to std::optional

### DIFF
--- a/bindings/python/vara-feature/pybind_FeatureModelXmlWriter.cpp
+++ b/bindings/python/vara-feature/pybind_FeatureModelXmlWriter.cpp
@@ -15,7 +15,7 @@ void init_xml_writer(py::module &M) {
       .def(
           "get_feature_model_as_string",
           [](vf::FeatureModelXmlWriter &Fmxw) {
-            return Fmxw.writeFeatureModel().getValueOr("");
+            return Fmxw.writeFeatureModel().value_or("");
           },
           R"pbdoc(Return the xml representation as string)pbdoc")
       .def(

--- a/bindings/python/vara-feature/pybind_FeatureSourceRange.cpp
+++ b/bindings/python/vara-feature/pybind_FeatureSourceRange.cpp
@@ -17,11 +17,11 @@ namespace vf = vara::feature;
 namespace py = pybind11;
 
 template <typename T>
-llvm::Optional<T> convertOptional(const std::optional<T> &Value) {
+std::optional<T> convertOptional(const std::optional<T> &Value) {
   if (Value.has_value()) {
     return {std::move(Value.value())};
   }
-  return llvm::None;
+  return std::nullopt;
 }
 
 void init_feature_location_module(py::module &M) {

--- a/include/vara/Configuration/Configuration.h
+++ b/include/vara/Configuration/Configuration.h
@@ -31,30 +31,29 @@ public:
 
   /// This method returns the string value of the configuration option.
   /// \returns the string value of the configuration option as a string
-  [[nodiscard]] llvm::Optional<llvm::StringRef> stringValue() const {
+  [[nodiscard]] std::optional<llvm::StringRef> stringValue() const {
     if (isString()) {
-      return llvm::Optional<llvm::StringRef>{
-          std::get<std::string>(this->Value)};
+      return std::optional<llvm::StringRef>{std::get<std::string>(this->Value)};
     }
-    return llvm::Optional<llvm::StringRef>{llvm::None};
+    return std::optional<llvm::StringRef>{std::nullopt};
   }
 
   /// This method returns the boolean value of the configuration option.
   /// \returns the boolean value of the configuration option as a bool
-  [[nodiscard]] llvm::Optional<bool> boolValue() const {
+  [[nodiscard]] std::optional<bool> boolValue() const {
     if (isBool()) {
-      return llvm::Optional<bool>{std::get<bool>(this->Value)};
+      return std::optional<bool>{std::get<bool>(this->Value)};
     }
-    return llvm::Optional<bool>{llvm::None};
+    return std::optional<bool>{std::nullopt};
   }
 
   /// This method returns the integer value of the configuration option.
   /// \returns the integer value of the configuration option as an int64_t
-  [[nodiscard]] llvm::Optional<int64_t> intValue() const {
+  [[nodiscard]] std::optional<int64_t> intValue() const {
     if (isInt()) {
-      return llvm::Optional<int64_t>{std::get<int64_t>(this->Value)};
+      return std::optional<int64_t>{std::get<int64_t>(this->Value)};
     }
-    return llvm::Optional<int64_t>{llvm::None};
+    return std::optional<int64_t>{std::nullopt};
   }
 
   /// This method returns the value as string no matter what the real type is.
@@ -62,11 +61,14 @@ public:
   [[nodiscard]] std::string asString() const {
     std::string ConvertedValue;
     if (isString()) {
-      ConvertedValue = stringValue().getValue();
+      // TODO: double check
+      ConvertedValue = stringValue().value();
     } else if (isBool()) {
-      ConvertedValue = boolValue().getValue() ? "true" : "false";
+      // TODO: double check
+      ConvertedValue = boolValue().value() ? "true" : "false";
     } else {
-      ConvertedValue = std::to_string(intValue().getValue());
+      // TODO: double check
+      ConvertedValue = std::to_string(intValue().value());
     }
     return ConvertedValue;
   }
@@ -162,7 +164,7 @@ public:
 
   /// This method returns the value of the configuration option.
   /// \returns the value of the configuration option as a string
-  [[nodiscard]] llvm::Optional<std::string>
+  [[nodiscard]] std::optional<std::string>
   configurationOptionValue(llvm::StringRef Name);
 
   /// This method dumps the current configuration to a json string.

--- a/include/vara/Configuration/Configuration.h
+++ b/include/vara/Configuration/Configuration.h
@@ -57,18 +57,22 @@ public:
   }
 
   /// This method returns the value as string no matter what the real type is.
+  ///
   /// \returns the value as string
   [[nodiscard]] std::string asString() const {
     std::string ConvertedValue;
     if (isString()) {
-      // TODO: double check
-      ConvertedValue = stringValue().value();
+      auto ParsedValue = stringValue();
+      assert(ParsedValue.has_value() && "Parsing <string> failed.");
+      ConvertedValue = ParsedValue.value();
     } else if (isBool()) {
-      // TODO: double check
-      ConvertedValue = boolValue().value() ? "true" : "false";
+      auto ParsedValue = boolValue();
+      assert(ParsedValue.has_value() && "Parsing <bool> failed.");
+      ConvertedValue = ParsedValue.value() ? "true" : "false";
     } else {
-      // TODO: double check
-      ConvertedValue = std::to_string(intValue().value());
+      auto ParsedValue = intValue();
+      assert(ParsedValue.has_value() && "Parsing <int> failed.");
+      ConvertedValue = std::to_string(ParsedValue.value());
     }
     return ConvertedValue;
   }

--- a/include/vara/Feature/ConstraintParser.h
+++ b/include/vara/Feature/ConstraintParser.h
@@ -53,7 +53,7 @@ public:
 
   [[nodiscard]] ConstraintTokenKind getKind() const { return Kind; };
 
-  [[nodiscard]] llvm::Optional<const std::string> getValue() const {
+  [[nodiscard]] std::optional<const std::string> getValue() const {
     return Value;
   }
 
@@ -89,7 +89,7 @@ public:
 
 private:
   const ConstraintTokenKind Kind;
-  const llvm::Optional<const std::string> Value{llvm::None};
+  const std::optional<const std::string> Value{std::nullopt};
 };
 
 //===----------------------------------------------------------------------===//
@@ -264,7 +264,7 @@ private:
 
 /// Parse 64-bit integer in decimal or scientific notation.
 static int64_t parseInteger(llvm::StringRef Str,
-                            llvm::Optional<unsigned int> Line = llvm::None) {
+                            std::optional<unsigned int> Line = std::nullopt) {
   if (Str.contains_insensitive('e')) {
     // If we encounter scientific notation we try to parse the number as double.
     if (double Double; !Str.getAsDouble(Double)) {
@@ -274,9 +274,9 @@ static int64_t parseInteger(llvm::StringRef Str,
     return Integer;
   }
 
-  if (Line.hasValue()) {
+  if (Line.has_value()) {
     llvm::errs() << "Failed to parse integer '" << Str << "' in line "
-                 << Line.hasValue() << ".\n";
+                 << Line.has_value() << ".\n";
   } else {
     llvm::errs() << "Failed to parse integer '" << Str << "'.\n";
   }
@@ -291,7 +291,7 @@ static int64_t parseInteger(llvm::StringRef Str,
 class ConstraintParser {
 public:
   explicit ConstraintParser(std::string Cnt,
-                            llvm::Optional<unsigned int> Line = llvm::None)
+                            std::optional<unsigned int> Line = std::nullopt)
       : TokenList(ConstraintLexer(std::move(Cnt)).tokenize()), Line(Line) {}
 
   std::unique_ptr<Constraint> buildConstraint() { return parseConstraint(); }
@@ -323,7 +323,7 @@ private:
     while (LHS) {
       switch (peek().getKind()) {
       case ConstraintToken::ConstraintTokenKind::ERROR:
-        assert(peek().getValue().hasValue());
+        assert(peek().getValue().has_value());
         llvm::errs() << "Lexical error: Unexpected character '"
                      << *peek().getValue() << "'\n";
         return nullptr;
@@ -393,7 +393,7 @@ private:
     while (true) {
       switch (peek().getKind()) {
       case ConstraintToken::ConstraintTokenKind::ERROR:
-        assert(peek().getValue().hasValue());
+        assert(peek().getValue().has_value());
         llvm::errs() << "Lexical error: Unexpected character '"
                      << *peek().getValue() << "'\n";
         return nullptr;
@@ -472,7 +472,7 @@ private:
     while (true) {
       switch (peek().getKind()) {
       case ConstraintToken::ConstraintTokenKind::ERROR:
-        assert(peek().getValue().hasValue());
+        assert(peek().getValue().has_value());
         llvm::errs() << "Lexical error: Unexpected character '"
                      << *peek().getValue() << "'\n";
         return nullptr;
@@ -502,11 +502,11 @@ private:
         llvm::errs() << "Syntax error: Unexpected closing parenthesis.\n";
         return nullptr;
       case ConstraintToken::ConstraintTokenKind::IDENTIFIER:
-        assert(peek().getValue().hasValue());
+        assert(peek().getValue().has_value());
         return std::make_unique<PrimaryFeatureConstraint>(
             std::make_unique<Feature>(*next().getValue()));
       case ConstraintToken::ConstraintTokenKind::NUMBER:
-        assert(peek().getValue().hasValue());
+        assert(peek().getValue().has_value());
         return std::make_unique<PrimaryIntegerConstraint>(
             parseInteger(*next().getValue(), Line));
       case ConstraintToken::ConstraintTokenKind::NOT:
@@ -530,7 +530,7 @@ private:
   }
 
   ConstraintLexer::TokenListTy TokenList;
-  llvm::Optional<unsigned int> Line;
+  std::optional<unsigned int> Line;
 };
 
 } // namespace vara::feature

--- a/include/vara/Feature/FeatureModelBuilder.h
+++ b/include/vara/Feature/FeatureModelBuilder.h
@@ -56,12 +56,12 @@ public:
     return this;
   }
 
-  [[nodiscard]] llvm::Optional<std::string>
+  [[nodiscard]] std::optional<std::string>
   getParentName(const std::string &FeatureName) const {
     if (const auto P = Parents.find(FeatureName); P != Parents.end()) {
       return P->getValue();
     }
-    return llvm::None;
+    return std::nullopt;
   }
 
   FeatureModelBuilder *emplaceRelationship(Relationship::RelationshipKind RK,

--- a/include/vara/Feature/FeatureModelParser.h
+++ b/include/vara/Feature/FeatureModelParser.h
@@ -220,7 +220,7 @@ private:
   ///
   /// \returns the cardinality of the given string and is empty if the
   /// format of the string is wrong
-  static llvm::Optional<std::tuple<int, int>>
+  static std::optional<std::tuple<int, int>>
   extractCardinality(llvm::StringRef StringToExtractFrom);
 
   /// This method parses the given cardinality and returns an optional.
@@ -232,8 +232,7 @@ private:
   ///
   /// \returns an optional that contains no integer in case of failure or
   /// UINT_MAX for wildcard, or the number itself.
-  static llvm::Optional<int>
-  parseCardinality(llvm::StringRef CardinalityString);
+  static std::optional<int> parseCardinality(llvm::StringRef CardinalityString);
 
   std::string Sxfm;
   FeatureModelBuilder FMB;

--- a/include/vara/Feature/FeatureModelWriter.h
+++ b/include/vara/Feature/FeatureModelWriter.h
@@ -27,7 +27,7 @@ public:
   ///
   /// \returns an instance of \a FeatureModel or \a nullptr
   virtual int writeFeatureModel(std::string Path) = 0;
-  virtual llvm::Optional<std::string> writeFeatureModel() = 0;
+  virtual std::optional<std::string> writeFeatureModel() = 0;
 };
 
 //===----------------------------------------------------------------------===//
@@ -40,7 +40,7 @@ public:
   explicit FeatureModelXmlWriter(const FeatureModel &Fm) : Fm{Fm} {}
 
   int writeFeatureModel(std::string Path) override;
-  llvm::Optional<std::string> writeFeatureModel() override;
+  std::optional<std::string> writeFeatureModel() override;
 
 private:
   int writeFeatureModel(xmlTextWriterPtr Writer);

--- a/include/vara/Feature/FeatureSourceRange.h
+++ b/include/vara/Feature/FeatureSourceRange.h
@@ -40,15 +40,15 @@ public:
       return Introduced;
     }
 
-    [[nodiscard]] bool hasRemovingCommit() const { return Removed.hasValue(); }
+    [[nodiscard]] bool hasRemovingCommit() const { return Removed.has_value(); }
     [[nodiscard]] llvm::StringRef removingCommit() const {
-      return Removed.hasValue() ? llvm::StringRef(Removed.getValue())
-                                : llvm::StringRef();
+      return Removed.has_value() ? llvm::StringRef(Removed.value())
+                                 : llvm::StringRef();
     }
 
   private:
     std::string Introduced;
-    llvm::Optional<std::string> Removed;
+    std::optional<std::string> Removed;
   };
 
   class FeatureSourceLocation {
@@ -94,26 +94,26 @@ public:
 
   class FeatureMemberOffset {
   public:
-    [[nodiscard]] static llvm::Optional<FeatureMemberOffset>
+    [[nodiscard]] static std::optional<FeatureMemberOffset>
     createFeatureMemberOffset(llvm::StringRef MemberOffset) {
       auto Split = splitMemberOffset(MemberOffset);
-      if (!Split.hasValue()) {
-        return llvm::None;
+      if (!Split.has_value()) {
+        return std::nullopt;
       }
-      return FeatureMemberOffset(splitClass(Split.getValue().first),
-                                 Split.getValue().second);
+      return FeatureMemberOffset(splitClass(Split.value().first),
+                                 Split.value().second);
     }
 
     [[nodiscard]] static bool
     isMemberOffsetFormat(llvm::StringRef PossibleMemberOffset) {
-      return splitMemberOffset(PossibleMemberOffset).hasValue();
+      return splitMemberOffset(PossibleMemberOffset).has_value();
     }
 
     [[nodiscard]] std::string
-    className(llvm::Optional<size_t> Nested = llvm::None) const {
-      if (Nested.hasValue()) {
-        assert(Nested.getValue() < Class.size());
-        return Class[Class.size() - Nested.getValue() - 1];
+    className(std::optional<size_t> Nested = std::nullopt) const {
+      if (Nested.has_value()) {
+        assert(Nested.value() < Class.size());
+        return Class[Class.size() - Nested.value() - 1];
       }
       std::stringstream StrS;
       StrS << Class[0];
@@ -145,12 +145,12 @@ public:
                         llvm::StringRef Member)
         : Class{Class.begin(), Class.end()}, Member(Member.str()) {}
 
-    static llvm::Optional<std::pair<llvm::StringRef, llvm::StringRef>>
+    static std::optional<std::pair<llvm::StringRef, llvm::StringRef>>
     splitMemberOffset(llvm::StringRef MemberOffset) {
       auto Split = MemberOffset.rsplit("::");
       if (Split.second.empty()) {
         // wrong format
-        return llvm::None;
+        return std::nullopt;
       }
       return Split;
     }
@@ -167,11 +167,11 @@ public:
   };
 
   FeatureSourceRange(
-      fs::path Path, llvm::Optional<FeatureSourceLocation> Start = llvm::None,
-      llvm::Optional<FeatureSourceLocation> End = llvm::None,
+      fs::path Path, std::optional<FeatureSourceLocation> Start = std::nullopt,
+      std::optional<FeatureSourceLocation> End = std::nullopt,
       Category CategoryKind = Category::necessary,
-      llvm::Optional<FeatureMemberOffset> MemberOffset = llvm::None,
-      llvm::Optional<FeatureRevisionRange> RevisionRange = llvm::None)
+      std::optional<FeatureMemberOffset> MemberOffset = std::nullopt,
+      std::optional<FeatureRevisionRange> RevisionRange = std::nullopt)
       : Path(std::move(Path)), Start(std::move(Start)), End(std::move(End)),
         CategoryKind(CategoryKind), MemberOffset(std::move(MemberOffset)),
         RevisionRange(std::move(RevisionRange)) {}
@@ -179,10 +179,10 @@ public:
   FeatureSourceRange(
       fs::path Path, FeatureSourceLocation Start, FeatureSourceLocation End,
       Category CategoryKind = Category::necessary,
-      llvm::Optional<FeatureMemberOffset> MemberOffset = llvm::None,
-      llvm::Optional<FeatureRevisionRange> RevisionRange = llvm::None)
-      : FeatureSourceRange(std::move(Path), llvm::Optional(std::move(Start)),
-                           llvm::Optional(std::move(End)), CategoryKind,
+      std::optional<FeatureMemberOffset> MemberOffset = std::nullopt,
+      std::optional<FeatureRevisionRange> RevisionRange = std::nullopt)
+      : FeatureSourceRange(std::move(Path), std::optional(std::move(Start)),
+                           std::optional(std::move(End)), CategoryKind,
                            std::move(MemberOffset), std::move(RevisionRange)) {}
 
   FeatureSourceRange(const FeatureSourceRange &L) = default;
@@ -200,26 +200,28 @@ public:
     this->Path = P;
   }
 
-  [[nodiscard]] bool hasStart() const { return Start.hasValue(); }
+  [[nodiscard]] bool hasStart() const { return Start.has_value(); }
   [[nodiscard]] FeatureSourceLocation *getStart() {
-    return Start.hasValue() ? Start.getPointer() : nullptr;
+    return Start.has_value() ? &Start.value() : nullptr;
   }
 
-  [[nodiscard]] bool hasEnd() const { return End.hasValue(); }
+  [[nodiscard]] bool hasEnd() const { return End.has_value(); }
   [[nodiscard]] FeatureSourceLocation *getEnd() {
-    return End.hasValue() ? End.getPointer() : nullptr;
+    return End.has_value() ? &End.value() : nullptr;
   }
 
-  [[nodiscard]] bool hasMemberOffset() const { return MemberOffset.hasValue(); }
+  [[nodiscard]] bool hasMemberOffset() const {
+    return MemberOffset.has_value();
+  }
   [[nodiscard]] FeatureMemberOffset *getMemberOffset() {
-    return MemberOffset.hasValue() ? MemberOffset.getPointer() : nullptr;
+    return MemberOffset.has_value() ? &MemberOffset.value() : nullptr;
   }
 
   [[nodiscard]] bool hasRevisionRange() const {
-    return RevisionRange.hasValue();
+    return RevisionRange.has_value();
   }
   [[nodiscard]] FeatureRevisionRange *revisionRange() {
-    return RevisionRange.hasValue() ? RevisionRange.getPointer() : nullptr;
+    return RevisionRange.has_value() ? &RevisionRange.value() : nullptr;
   }
 
   [[nodiscard]] std::string toString() const {
@@ -249,11 +251,11 @@ public:
 
 private:
   fs::path Path;
-  llvm::Optional<FeatureSourceLocation> Start;
-  llvm::Optional<FeatureSourceLocation> End;
+  std::optional<FeatureSourceLocation> Start;
+  std::optional<FeatureSourceLocation> End;
   Category CategoryKind;
-  llvm::Optional<FeatureMemberOffset> MemberOffset;
-  llvm::Optional<FeatureRevisionRange> RevisionRange;
+  std::optional<FeatureMemberOffset> MemberOffset;
+  std::optional<FeatureRevisionRange> RevisionRange;
 };
 } // namespace vara::feature
 

--- a/lib/Configuration/Configuration.cpp
+++ b/lib/Configuration/Configuration.cpp
@@ -54,13 +54,13 @@ void Configuration::setConfigurationOption(llvm::StringRef Name,
   addConfigurationOption(std::move(Option));
 }
 
-llvm::Optional<std::string>
+std::optional<std::string>
 Configuration::configurationOptionValue(llvm::StringRef Name) {
   auto Search = this->OptionMappings.find(Name);
   if (Search == this->OptionMappings.end()) {
-    return llvm::Optional<std::string>{};
+    return std::optional<std::string>{};
   }
-  return llvm::Optional<std::string>{Search->second->asString()};
+  return std::optional<std::string>{Search->second->asString()};
 }
 
 std::string Configuration::dumpToString() {

--- a/lib/Feature/FeatureModelParser.cpp
+++ b/lib/Feature/FeatureModelParser.cpp
@@ -156,11 +156,11 @@ FeatureModelXmlParser::parseConfigurationOption(xmlNode *Node,
 FeatureSourceRange
 FeatureModelXmlParser::createFeatureSourceRange(xmlNode *Node) {
   fs::path Path;
-  llvm::Optional<FeatureSourceRange::FeatureSourceLocation> Start;
-  llvm::Optional<FeatureSourceRange::FeatureSourceLocation> End;
+  std::optional<FeatureSourceRange::FeatureSourceLocation> Start;
+  std::optional<FeatureSourceRange::FeatureSourceLocation> End;
   enum FeatureSourceRange::Category Category;
-  llvm::Optional<FeatureSourceRange::FeatureMemberOffset> MemberOffset;
-  llvm::Optional<FeatureSourceRange::FeatureRevisionRange> RevisionRange;
+  std::optional<FeatureSourceRange::FeatureMemberOffset> MemberOffset;
+  std::optional<FeatureSourceRange::FeatureRevisionRange> RevisionRange;
 
   std::unique_ptr<xmlChar, void (*)(void *)> Tmp(
       xmlGetProp(Node, XmlConstants::CATEGORY), xmlFree);
@@ -560,7 +560,7 @@ bool FeatureModelSxfmParser::parseFeatureTree(xmlNode *FeatureTree) {
       // the feature (m for mandatory, o for optional, a for alternative)
       std::string::size_type Pos =
           CurrentIndentationLevel * Indentation.length() + 2;
-      llvm::Optional<std::tuple<int, int>> Cardinalities;
+      std::optional<std::tuple<int, int>> Cardinalities;
 
       switch (To.at(Pos - 1)) {
       case 'r':
@@ -577,7 +577,7 @@ bool FeatureModelSxfmParser::parseFeatureTree(xmlNode *FeatureTree) {
         Opt = false;
         // Extract the cardinality
         Cardinalities = extractCardinality(To);
-        if (!Cardinalities.hasValue()) {
+        if (!Cardinalities.has_value()) {
           return false;
         }
         break;
@@ -674,10 +674,10 @@ bool FeatureModelSxfmParser::parseFeatureTree(xmlNode *FeatureTree) {
       }
 
       // Remember the new or group parent if there is one
-      if (Cardinalities.hasValue()) {
+      if (Cardinalities.has_value()) {
         Relationship::RelationshipKind GroupKind =
             Relationship::RelationshipKind::RK_ALTERNATIVE;
-        if (std::get<1>(Cardinalities.getValue()) == SxfmConstants::WILDCARD) {
+        if (std::get<1>(Cardinalities.value()) == SxfmConstants::WILDCARD) {
           GroupKind = Relationship::RelationshipKind::RK_OR;
         }
         OrGroupMapping[CurrentIndentationLevel] =
@@ -772,10 +772,10 @@ bool FeatureModelSxfmParser::parseConstraints(xmlNode *Constraints) {
   return true;
 }
 
-llvm::Optional<std::tuple<int, int>> FeatureModelSxfmParser::extractCardinality(
+std::optional<std::tuple<int, int>> FeatureModelSxfmParser::extractCardinality(
     llvm::StringRef StringToExtractFrom) {
-  llvm::Optional<int> MinCardinality;
-  llvm::Optional<int> MaxCardinality;
+  std::optional<int> MinCardinality;
+  std::optional<int> MaxCardinality;
 
   // Search for the first occurrence of '['; then read in the min cardinality
   // until the comma. Afterwards, read in the max cardinality until ']'
@@ -794,26 +794,25 @@ llvm::Optional<std::tuple<int, int>> FeatureModelSxfmParser::extractCardinality(
           .substr(Pos + 1, CardinalityString.find(']', Pos + 1) - Pos - 1)
           .str());
 
-  if (!MinCardinality.hasValue() || !MaxCardinality.hasValue()) {
+  if (!MinCardinality.has_value() || !MaxCardinality.has_value()) {
     llvm::errs() << "No parsable cardinality!\n";
     return {};
   }
 
-  if (MinCardinality.getValue() != 1 ||
-      (MaxCardinality.getValue() != 1 &&
-       MaxCardinality.getValue() != SxfmConstants::WILDCARD)) {
+  if (MinCardinality.value() != 1 ||
+      (MaxCardinality.value() != 1 &&
+       MaxCardinality.value() != SxfmConstants::WILDCARD)) {
     llvm::errs() << "Cardinality unsupported. We support cardinalities [1,1] "
                     "(alternative) or [1, *] (or group).\n";
     return {};
   }
 
-  return {std::tuple<int, int>{MinCardinality.getValue(),
-                               MaxCardinality.getValue()}};
+  return {std::tuple<int, int>{MinCardinality.value(), MaxCardinality.value()}};
 }
 
-llvm::Optional<int>
+std::optional<int>
 FeatureModelSxfmParser::parseCardinality(llvm::StringRef CardinalityString) {
-  llvm::Optional<int> Result;
+  std::optional<int> Result;
   if (CardinalityString == "*") {
     // We use -1 as our magic integer to indicate that the cardinality is a
     // wildcard.

--- a/lib/Feature/FeatureModelTransaction.cpp
+++ b/lib/Feature/FeatureModelTransaction.cpp
@@ -49,13 +49,13 @@ Feature *getActualFeature(FeatureModel &FM, detail::FeatureVariantTy &FV) {
   return ActualFeature;
 }
 
-llvm::Optional<bool> fvIsLeaf(FeatureModel &FM, detail::FeatureVariantTy &FV) {
+std::optional<bool> fvIsLeaf(FeatureModel &FM, detail::FeatureVariantTy &FV) {
   Feature *ActualFeature = getActualFeature(FM, FV);
   // if Feature does not exist in FM
   if (ActualFeature == nullptr) {
-    return llvm::None;
+    return std::nullopt;
   }
-  return llvm::Optional<bool>{ActualFeature->isLeaf()};
+  return std::optional<bool>{ActualFeature->isLeaf()};
 }
 
 /// Checks if in recursive mode the provided Feature can be deleted or not.
@@ -66,12 +66,12 @@ llvm::Optional<bool> fvIsLeaf(FeatureModel &FM, detail::FeatureVariantTy &FV) {
 /// \return optional of true, if all transitive children of FV are not part of
 /// OtherFeatures; optional of false, if at least one transitive child of FV is
 /// part of OtherFeatures; nullopt, if FV is not part of FM
-llvm::Optional<bool>
+std::optional<bool>
 canBeDeletedRecursively(FeatureModel &FM, detail::FeatureVariantTy &FV,
                         const std::set<FeatureTreeNode *> &OtherFeatures) {
   Feature *ActualFeature = getActualFeature(FM, FV);
   if (ActualFeature == nullptr) { // Feature does not exist in FM
-    return llvm::None;
+    return std::nullopt;
   }
 
   std::set<FeatureTreeNode *> Intersection;
@@ -82,7 +82,7 @@ canBeDeletedRecursively(FeatureModel &FM, detail::FeatureVariantTy &FV,
                         std::inserter(Intersection, Intersection.begin()));
   // if the children are not matching the other features, the intersection is
   // empty and we are good to go for deletion
-  return llvm::Optional<bool>{Intersection.begin() == Intersection.end()};
+  return std::optional<bool>{Intersection.begin() == Intersection.end()};
 }
 
 std::vector<detail::FeatureVariantTy> removeFeatures(
@@ -110,13 +110,13 @@ std::vector<detail::FeatureVariantTy> removeFeatures(
   auto DeleteIt = std::partition(
       Begin, End,
       [&FM, Recursive, &OtherFeatures](detail::FeatureVariantTy &FV) {
-        if (fvIsLeaf(FM, FV).getValueOr(false)) {
+        if (fvIsLeaf(FM, FV).value_or(false)) {
           return true;
         }
         if (!Recursive) {
           return false;
         }
-        return canBeDeletedRecursively(FM, FV, OtherFeatures).getValueOr(false);
+        return canBeDeletedRecursively(FM, FV, OtherFeatures).value_or(false);
       });
 
   // check if something can be deleted --> if not and return non-deletable

--- a/lib/Feature/FeatureModelWriter.cpp
+++ b/lib/Feature/FeatureModelWriter.cpp
@@ -34,7 +34,7 @@ int FeatureModelXmlWriter::writeFeatureModel(std::string Path) {
   return RC;
 }
 
-llvm::Optional<std::string> FeatureModelXmlWriter::writeFeatureModel() {
+std::optional<std::string> FeatureModelXmlWriter::writeFeatureModel() {
   int RC;
 
   std::unique_ptr<xmlDocPtr, void (*)(xmlDocPtr *)> DocPtrPtr(
@@ -48,11 +48,11 @@ llvm::Optional<std::string> FeatureModelXmlWriter::writeFeatureModel() {
   std::unique_ptr<xmlTextWriter, void (*)(xmlTextWriterPtr)> Writer(
       xmlNewTextWriterDoc(DocPtrPtr.get(), 0), &xmlFreeTextWriter);
   if (!Writer) {
-    return llvm::None;
+    return std::nullopt;
   }
   RC = writeFeatureModel(Writer.get());
   if (RC < 0) {
-    return llvm::None;
+    return std::nullopt;
   }
 
   std::unique_ptr<xmlChar *, void (*)(xmlChar **)> XmlBuffPtr(

--- a/lib/Sampling/SampleSetWriter.cpp
+++ b/lib/Sampling/SampleSetWriter.cpp
@@ -27,9 +27,12 @@ std::string vara::sampling::SampleSetWriter::writeConfigurations(
         ConfigurationStringFlags.append("\"");
         ConfigurationStringFlags.append(F->getOutputString().str());
         if (F->getKind() == feature::Feature::FeatureKind::FK_NUMERIC) {
-          ConfigurationStringFlags.append(
-              // TODO: insert check if optional is empty
-              Configuration->configurationOptionValue(F->getName()).value());
+          auto OptionValue =
+              Configuration->configurationOptionValue(F->getName());
+          assert(
+              OptionValue.has_value() &&
+              "Could not retrieve option value, broken configuration option.");
+          ConfigurationStringFlags.append(OptionValue.value());
         }
         ConfigurationStringFlags.append("\"");
       }

--- a/lib/Sampling/SampleSetWriter.cpp
+++ b/lib/Sampling/SampleSetWriter.cpp
@@ -20,8 +20,7 @@ std::string vara::sampling::SampleSetWriter::writeConfigurations(
     auto &Configuration = Configurations.at(ConfigurationCount);
     for (auto *F : FM.features()) {
       if (auto Value = Configuration->configurationOptionValue(F->getName());
-          Value && Value.getValue() != "false" &&
-          !F->getOutputString().empty()) {
+          Value && Value.value() != "false" && !F->getOutputString().empty()) {
         if (ConfigurationStringFlags.size() != 1) {
           ConfigurationStringFlags.append(", ");
         }
@@ -29,7 +28,8 @@ std::string vara::sampling::SampleSetWriter::writeConfigurations(
         ConfigurationStringFlags.append(F->getOutputString().str());
         if (F->getKind() == feature::Feature::FeatureKind::FK_NUMERIC) {
           ConfigurationStringFlags.append(
-              Configuration->configurationOptionValue(F->getName()).getValue());
+              // TODO: insert check if optional is empty
+              Configuration->configurationOptionValue(F->getName()).value());
         }
         ConfigurationStringFlags.append("\"");
       }

--- a/tools/fm-viewer/FeatureModelViewer.cpp
+++ b/tools/fm-viewer/FeatureModelViewer.cpp
@@ -80,7 +80,7 @@ int main(int Argc, char **Argv) {
             Viewer.empty() ? llvm::errc::invalid_argument
                            : llvm::sys::findProgramByName(Viewer)) {
       llvm::errs() << "Trying '" << *P << "' program... \n";
-      llvm::sys::ExecuteNoWait(*P, {*P, Filename}, llvm::None);
+      llvm::sys::ExecuteNoWait(*P, {*P, Filename}, std::nullopt);
     } else {
       llvm::DisplayGraph(Filename);
     }

--- a/tools/fm-viewer/FeatureModelViewer.cpp
+++ b/tools/fm-viewer/FeatureModelViewer.cpp
@@ -80,9 +80,7 @@ int main(int Argc, char **Argv) {
             Viewer.empty() ? llvm::errc::invalid_argument
                            : llvm::sys::findProgramByName(Viewer)) {
       llvm::errs() << "Trying '" << *P << "' program... \n";
-      llvm::sys::ExecuteNoWait(
-          *P, {*P, Filename},
-          std::optional<llvm::ArrayRef<llvm::StringRef>>{std::nullopt});
+      llvm::sys::ExecuteNoWait(*P, {*P, Filename}, llvm::None);
     } else {
       llvm::DisplayGraph(Filename);
     }

--- a/tools/fm-viewer/FeatureModelViewer.cpp
+++ b/tools/fm-viewer/FeatureModelViewer.cpp
@@ -80,7 +80,9 @@ int main(int Argc, char **Argv) {
             Viewer.empty() ? llvm::errc::invalid_argument
                            : llvm::sys::findProgramByName(Viewer)) {
       llvm::errs() << "Trying '" << *P << "' program... \n";
-      llvm::sys::ExecuteNoWait(*P, {*P, Filename}, std::nullopt);
+      llvm::sys::ExecuteNoWait(
+          *P, {*P, Filename},
+          std::optional<llvm::ArrayRef<llvm::StringRef>>{std::nullopt});
     } else {
       llvm::DisplayGraph(Filename);
     }

--- a/unittests/Configuration/Configuration.cpp
+++ b/unittests/Configuration/Configuration.cpp
@@ -36,8 +36,8 @@ TEST(Configuration, dumpTest) {
   EXPECT_EQ(ConfigurationString, Dump);
   Config.setConfigurationOption("foo_baz", "2");
   EXPECT_EQ(R"({"baz":"1","foo":"true","foo_baz":"2"})", Config.dumpToString());
-  EXPECT_EQ("2", Config.configurationOptionValue("foo_baz").getValue());
-  EXPECT_FALSE(Config.configurationOptionValue("a").hasValue());
+  EXPECT_EQ("2", Config.configurationOptionValue("foo_baz").value());
+  EXPECT_FALSE(Config.configurationOptionValue("a").has_value());
   EXPECT_EQ(R"({"baz":"1","foo":"true","foo_baz":"2"})", Config.dumpToString());
 }
 
@@ -45,7 +45,7 @@ TEST(Configuration, addConfigurationMultipleTimes) {
   Configuration Config{};
   Config.setConfigurationOption("foo", "1");
   Config.setConfigurationOption("foo", "true");
-  EXPECT_EQ("true", Config.configurationOptionValue("foo").getValue());
+  EXPECT_EQ("true", Config.configurationOptionValue("foo").value());
 }
 
 TEST(Configuration, iteratorTest) {

--- a/unittests/Configuration/ConfigurationOption.cpp
+++ b/unittests/Configuration/ConfigurationOption.cpp
@@ -9,7 +9,7 @@ TEST(ConfigurationOption, basicAccessors) {
   EXPECT_TRUE(FalseOption.isBool());
   EXPECT_FALSE(FalseOption.isInt());
   EXPECT_FALSE(FalseOption.isString());
-  EXPECT_FALSE(FalseOption.boolValue().getValue());
+  EXPECT_FALSE(FalseOption.boolValue().value());
   EXPECT_EQ("false", FalseOption.asString());
   EXPECT_EQ("foo: false", FalseOption.toString());
 
@@ -18,7 +18,7 @@ TEST(ConfigurationOption, basicAccessors) {
   EXPECT_TRUE(Option.isBool());
   EXPECT_FALSE(Option.isInt());
   EXPECT_FALSE(Option.isString());
-  EXPECT_TRUE(Option.boolValue().getValue());
+  EXPECT_TRUE(Option.boolValue().value());
   EXPECT_EQ("true", Option.asString());
   EXPECT_EQ("foo: true", Option.toString());
 
@@ -27,7 +27,7 @@ TEST(ConfigurationOption, basicAccessors) {
   EXPECT_TRUE(Option2.isInt());
   EXPECT_FALSE(Option2.isString());
   EXPECT_FALSE(Option2.isBool());
-  EXPECT_EQ(1, Option2.intValue().getValue());
+  EXPECT_EQ(1, Option2.intValue().value());
   EXPECT_EQ("1", Option2.asString());
   EXPECT_EQ("baz: 1", Option2.toString());
 
@@ -36,25 +36,25 @@ TEST(ConfigurationOption, basicAccessors) {
   EXPECT_TRUE(UnparseableOption.isString());
   EXPECT_FALSE(UnparseableOption.isBool());
   EXPECT_FALSE(UnparseableOption.isInt());
-  EXPECT_EQ("test", UnparseableOption.stringValue().getValue());
+  EXPECT_EQ("test", UnparseableOption.stringValue().value());
   EXPECT_EQ("test", UnparseableOption.asString());
   EXPECT_EQ("foobar: test", UnparseableOption.toString());
 }
 
 TEST(ConfigurationOption, negativeTests) {
   ConfigurationOption TrueOption("o", "false");
-  EXPECT_FALSE(TrueOption.stringValue().hasValue());
-  EXPECT_FALSE(TrueOption.intValue().hasValue());
-  EXPECT_FALSE(TrueOption.boolValue().getValue());
+  EXPECT_FALSE(TrueOption.stringValue().has_value());
+  EXPECT_FALSE(TrueOption.intValue().has_value());
+  EXPECT_FALSE(TrueOption.boolValue().value());
 
   ConfigurationOption IntOption("p", "42");
-  EXPECT_EQ(42, IntOption.intValue().getValue());
-  EXPECT_FALSE(IntOption.stringValue().hasValue());
-  EXPECT_FALSE(IntOption.boolValue().hasValue());
+  EXPECT_EQ(42, IntOption.intValue().value());
+  EXPECT_FALSE(IntOption.stringValue().has_value());
+  EXPECT_FALSE(IntOption.boolValue().has_value());
 
   ConfigurationOption StringOption("q", "test");
-  EXPECT_EQ("test", StringOption.stringValue().getValue());
-  EXPECT_FALSE(StringOption.intValue().hasValue());
-  EXPECT_FALSE(StringOption.boolValue().hasValue());
+  EXPECT_EQ("test", StringOption.stringValue().value());
+  EXPECT_FALSE(StringOption.intValue().has_value());
+  EXPECT_FALSE(StringOption.boolValue().has_value());
 }
 } // namespace vara::feature

--- a/unittests/Feature/FeatureModelWriter.cpp
+++ b/unittests/Feature/FeatureModelWriter.cpp
@@ -19,8 +19,8 @@ TEST(XmlWriter, children) {
 
   FeatureModelXmlWriter Fmxw = FeatureModelXmlWriter(*FM);
   auto Output = Fmxw.writeFeatureModel();
-  EXPECT_TRUE(Output.hasValue());
-  std::string ActualOutput = Output.getValue();
+  EXPECT_TRUE(Output.has_value());
+  std::string ActualOutput = Output.value();
   EXPECT_FALSE(ActualOutput.empty());
 
   std::string ExpectedOutput = FS.get()->getBuffer().str();
@@ -36,8 +36,8 @@ TEST(XmlWriter, excludes) {
 
   FeatureModelXmlWriter Fmxw = FeatureModelXmlWriter(*FM);
   auto Output = Fmxw.writeFeatureModel();
-  EXPECT_TRUE(Output.hasValue());
-  std::string ActualOutput = Output.getValue();
+  EXPECT_TRUE(Output.has_value());
+  std::string ActualOutput = Output.value();
   EXPECT_FALSE(ActualOutput.empty());
 
   std::string ExpectedOutput = FS.get()->getBuffer().str();
@@ -52,8 +52,8 @@ TEST(XmlWriter, test) {
 
   FeatureModelXmlWriter Fmxw = FeatureModelXmlWriter(*FM);
   auto Output = Fmxw.writeFeatureModel();
-  EXPECT_TRUE(Output.hasValue());
-  std::string ActualOutput = Output.getValue();
+  EXPECT_TRUE(Output.has_value());
+  std::string ActualOutput = Output.value();
   EXPECT_FALSE(ActualOutput.empty());
 
   FS = llvm::MemoryBuffer::getFileAsStream(getTestResource("test.xml"));

--- a/unittests/Feature/FeatureSourceRange.cpp
+++ b/unittests/Feature/FeatureSourceRange.cpp
@@ -18,7 +18,7 @@ TEST(FeatureSourceRange, full) {
       FeatureSourceRange::Category::inessential,
       FeatureSourceRange::FeatureMemberOffset::createFeatureMemberOffset(
           "class::memberOffset")
-          .getValue(),
+          .value(),
       FeatureSourceRange::FeatureRevisionRange(
           "94fe792df46e64f438720295742b3b72c407cab6",
           "1ed40f72e772adaa3adfcc94b9f038e4f3382339"));
@@ -90,28 +90,28 @@ TEST(FeatureMemberOffset, testFactoryMethod) {
   EXPECT_TRUE(
       FeatureSourceRange::FeatureMemberOffset::createFeatureMemberOffset(
           "::member")
-          .hasValue());
+          .has_value());
   EXPECT_TRUE(
       FeatureSourceRange::FeatureMemberOffset::createFeatureMemberOffset(
           "foo::member")
-          .hasValue());
+          .has_value());
   EXPECT_TRUE(
       FeatureSourceRange::FeatureMemberOffset::createFeatureMemberOffset(
           "foo::bar::member")
-          .hasValue());
+          .has_value());
 
   EXPECT_FALSE(
       FeatureSourceRange::FeatureMemberOffset::createFeatureMemberOffset(
           "foo:bar")
-          .hasValue());
+          .has_value());
   EXPECT_FALSE(
       FeatureSourceRange::FeatureMemberOffset::createFeatureMemberOffset(
           "member")
-          .hasValue());
+          .has_value());
   EXPECT_FALSE(
       FeatureSourceRange::FeatureMemberOffset::createFeatureMemberOffset(
           "foo::")
-          .hasValue());
+          .has_value());
 }
 
 TEST(FeatureMemberOffset, basicAccessor) {
@@ -127,12 +127,12 @@ TEST(FeatureMemberOffset, individualAccessors) {
       FeatureSourceRange::FeatureMemberOffset::createFeatureMemberOffset(
           "foo::bar::member");
 
-  ASSERT_TRUE(Member.hasValue());
+  ASSERT_TRUE(Member.has_value());
 
-  EXPECT_EQ(Member.getValue().className(), "foo::bar");
-  EXPECT_EQ(Member.getValue().className(0), "bar");
-  EXPECT_EQ(Member.getValue().className(1), "foo");
-  EXPECT_EQ(Member.getValue().memberName(), "member");
+  EXPECT_EQ(Member.value().className(), "foo::bar");
+  EXPECT_EQ(Member.value().className(0), "bar");
+  EXPECT_EQ(Member.value().className(1), "foo");
+  EXPECT_EQ(Member.value().memberName(), "member");
 }
 
 TEST(FeatureMemberOffset, anonymous) {
@@ -141,8 +141,8 @@ TEST(FeatureMemberOffset, anonymous) {
           "::member");
 
   EXPECT_EQ(Member->toString(), "::member");
-  EXPECT_EQ(Member.getValue().className(), "");
-  EXPECT_EQ(Member.getValue().memberName(), "member");
+  EXPECT_EQ(Member.value().className(), "");
+  EXPECT_EQ(Member.value().memberName(), "member");
 }
 
 TEST(FeatureMemberOffset, comparison) {
@@ -156,13 +156,13 @@ TEST(FeatureMemberOffset, comparison) {
       FeatureSourceRange::FeatureMemberOffset::createFeatureMemberOffset(
           "class::member2");
 
-  ASSERT_TRUE(Member1.hasValue());
-  ASSERT_TRUE(Member2.hasValue());
-  ASSERT_TRUE(Member3.hasValue());
+  ASSERT_TRUE(Member1.has_value());
+  ASSERT_TRUE(Member2.has_value());
+  ASSERT_TRUE(Member3.has_value());
 
-  EXPECT_NE(Member1.getValue(), Member2.getValue());
-  EXPECT_NE(Member1.getValue(), Member3.getValue());
-  EXPECT_EQ(Member2.getValue(), Member3.getValue());
+  EXPECT_NE(Member1.value(), Member2.value());
+  EXPECT_NE(Member1.value(), Member3.value());
+  EXPECT_EQ(Member2.value(), Member3.value());
 }
 
 TEST(FeatureSourceRange, basicAccessors) {
@@ -197,32 +197,32 @@ TEST(FeatureSourceRange, comparison) {
   const auto MemOff1 =
       FeatureSourceRange::FeatureMemberOffset::createFeatureMemberOffset(
           "class::memberOffset1");
-  ASSERT_TRUE(MemOff1.hasValue());
+  ASSERT_TRUE(MemOff1.has_value());
 
   const auto MemOff2 =
       FeatureSourceRange::FeatureMemberOffset::createFeatureMemberOffset(
           "class::memberOffset2");
-  ASSERT_TRUE(MemOff2.hasValue());
+  ASSERT_TRUE(MemOff2.has_value());
 
   const auto MemOff3 =
       FeatureSourceRange::FeatureMemberOffset::createFeatureMemberOffset(
           "class::memberOffset2");
-  ASSERT_TRUE(MemOff3.hasValue());
+  ASSERT_TRUE(MemOff3.has_value());
 
   auto L1 = FeatureSourceRange(
       "path1", FeatureSourceRange::FeatureSourceLocation(1, 2),
       FeatureSourceRange::FeatureSourceLocation(1, 20),
-      FeatureSourceRange::Category::inessential, MemOff1.getValue());
+      FeatureSourceRange::Category::inessential, MemOff1.value());
 
   auto L2 = FeatureSourceRange(
       "path2", FeatureSourceRange::FeatureSourceLocation(1, 2),
       FeatureSourceRange::FeatureSourceLocation(1, 20),
-      FeatureSourceRange::Category::inessential, MemOff2.getValue());
+      FeatureSourceRange::Category::inessential, MemOff2.value());
 
   auto L3 = FeatureSourceRange(
       "path2", FeatureSourceRange::FeatureSourceLocation(1, 2),
       FeatureSourceRange::FeatureSourceLocation(1, 20),
-      FeatureSourceRange::Category::inessential, MemOff3.getValue());
+      FeatureSourceRange::Category::inessential, MemOff3.value());
 
   EXPECT_NE(L1, L2);
   EXPECT_NE(L1, L3);
@@ -236,7 +236,7 @@ TEST(FeatureSourceRange, clone) {
       FeatureSourceRange::Category::inessential,
       FeatureSourceRange::FeatureMemberOffset::createFeatureMemberOffset(
           "class::memberOffset")
-          .getValue());
+          .value());
 
   auto Clone = FeatureSourceRange(*FSR);
   FSR.reset();

--- a/unittests/Feature/FeatureSourceRange.cpp
+++ b/unittests/Feature/FeatureSourceRange.cpp
@@ -186,7 +186,7 @@ TEST(FeatureSourceRange, onlyStart) {
 }
 
 TEST(FeatureSourceRange, onlyEnd) {
-  auto L = FeatureSourceRange(fs::current_path(), llvm::None,
+  auto L = FeatureSourceRange(fs::current_path(), std::nullopt,
                               FeatureSourceRange::FeatureSourceLocation(3, 5));
 
   EXPECT_FALSE(L.hasStart());

--- a/unittests/Sampling/SampleSetParserTests.cpp
+++ b/unittests/Sampling/SampleSetParserTests.cpp
@@ -14,7 +14,7 @@ inline void testConfigurationOption(
     llvm::StringRef Feature, llvm::StringRef ExpectedValue) {
   auto Value = Config->configurationOptionValue(Feature);
   EXPECT_TRUE(Value);
-  EXPECT_EQ(Value.getValue(), ExpectedValue.str());
+  EXPECT_EQ(Value.value(), ExpectedValue.str());
 }
 
 namespace vara::sampling {

--- a/unittests/Sampling/SampleSetWriterTests.cpp
+++ b/unittests/Sampling/SampleSetWriterTests.cpp
@@ -15,7 +15,7 @@ inline void testConfigurationOption(
     llvm::StringRef Feature, llvm::StringRef ExpectedValue) {
   auto Value = Config->configurationOptionValue(Feature);
   EXPECT_TRUE(Value);
-  EXPECT_EQ(Value.getValue(), ExpectedValue.str());
+  EXPECT_EQ(Value.value(), ExpectedValue.str());
 }
 
 namespace vara::sampling {


### PR DESCRIPTION
As LLVM is currently in the process of removing llvm::Optional with 17, we should already start to switch to std::optional.