### PR TITLE
Cleans up error handling

### DIFF
--- a/bindings/python/vara-feature/pybind_FeatureModelBuilder.cpp
+++ b/bindings/python/vara-feature/pybind_FeatureModelBuilder.cpp
@@ -6,6 +6,7 @@
 #include "pybind11/stl.h"
 #include "pybind_common.h"
 
+#include <cassert>
 #include <filesystem>
 #include <memory>
 
@@ -35,7 +36,8 @@ void init_feature_model_builder_module(py::module &M) {
             vf::Relationship::RelationshipKind RK;
             if (relation == "OR") {
               RK = vf::Relationship::RelationshipKind::RK_OR;
-            } else if (relation == "XOR") {
+            } else {
+              assert(relation == "XOR" && "relation had unhandled kind");
               RK = vf::Relationship::RelationshipKind::RK_ALTERNATIVE;
             }
             return FMB.emplaceRelationship(RK, parent_name);

--- a/include/vara/Feature/StepFunction.h
+++ b/include/vara/Feature/StepFunction.h
@@ -1,6 +1,7 @@
 #ifndef VARA_FEATURE_STEPFUNCTION_H
 #define VARA_FEATURE_STEPFUNCTION_H
 
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FormatVariadic.h"
 
 #include <cmath>
@@ -36,10 +37,9 @@ public:
         return Value * std::get<double>(RHS);
       case StepOperation::EXPONENTIATION:
         return std::pow(Value, std::get<double>(RHS));
-      default:
-        static_assert("Missing operation has to be implemented!");
-        return Value;
       }
+
+      llvm_unreachable("Missing operation has to be implemented!");
     }
     assert(std::holds_alternative<double>(LHS));
     switch (Op) {
@@ -49,10 +49,9 @@ public:
       return std::get<double>(LHS) * Value;
     case StepOperation::EXPONENTIATION:
       return std::pow(std::get<double>(LHS), Value);
-    default:
-      static_assert("Missing operation has to be implemented!");
-      return Value;
     }
+
+    llvm_unreachable("Missing operation has to be implemented!");
   }
 
   [[nodiscard]] double operator()(double Value) { return next(Value); }

--- a/lib/Solver/Z3Solver.cpp
+++ b/lib/Solver/Z3Solver.cpp
@@ -1,5 +1,7 @@
 #include "vara/Solver/Z3Solver.h"
 
+#include "llvm/Support/ErrorHandling.h"
+
 #include "z3++.h"
 
 namespace vara::solver {
@@ -344,7 +346,7 @@ bool Z3SolverConstraintVisitor::visit(vara::feature::BinaryConstraint *C) {
                              z3::implies(Z3ConstraintExpression, !Left);
     break;
   default:
-    static_assert(
+    llvm_unreachable(
         "Unimplemented binary constraint in Z3SolverConstraintVisitor "
         "detected!");
     return false;


### PR DESCRIPTION
Replace static_assert with unreachable and add assert instead of call to uninitialized value.