### PR TITLE
Make vara-feature compatible to newer LLVM versions

### DIFF
--- a/include/vara/Feature/ConstraintParser.h
+++ b/include/vara/Feature/ConstraintParser.h
@@ -15,6 +15,18 @@ namespace vara::feature {
 //                               ConstraintToken
 //===----------------------------------------------------------------------===//
 
+namespace legacy {
+// NOLINTNEXTLINE(readability-identifier-naming)
+[[nodiscard]] inline bool starts_with(llvm::StringRef Str,
+                                      llvm::StringRef Prefix) {
+#if LLVM_VERSION_MAJOR <= 14
+  return Str.startswith(Prefix);
+#else
+  return Str.starts_with(Prefix);
+#endif
+}
+} // namespace legacy
+
 class ConstraintToken {
 public:
   using PrecedenceTy = unsigned int;
@@ -187,26 +199,26 @@ private:
   static ResultTy munchOperator(const llvm::StringRef &Str) {
     switch (Str.front()) {
     case '-':
-      if (Str.startswith("->")) {
+      if (legacy::starts_with(Str, "->")) {
         return {ConstraintToken(ConstraintToken::ConstraintTokenKind::IMPLIES),
                 2};
       }
       return {ConstraintToken(ConstraintToken::ConstraintTokenKind::MINUS), 1};
     case '!':
-      if (Str.startswith("!=")) {
+      if (legacy::starts_with(Str, "!=")) {
         return {
             ConstraintToken(ConstraintToken::ConstraintTokenKind::NOT_EQUAL),
             2};
       }
       return {ConstraintToken(ConstraintToken::ConstraintTokenKind::NOT), 1};
     case '=':
-      if (Str.startswith("=>")) {
+      if (legacy::starts_with(Str, "=>")) {
         return {ConstraintToken(ConstraintToken::ConstraintTokenKind::IMPLIES),
                 2};
       }
       return {ConstraintToken(ConstraintToken::ConstraintTokenKind::EQUAL), 1};
     case '>':
-      if (Str.startswith(">=")) {
+      if (legacy::starts_with(Str, ">=")) {
         return {ConstraintToken(
                     ConstraintToken::ConstraintTokenKind::GREATER_EQUAL),
                 2};
@@ -214,11 +226,11 @@ private:
       return {ConstraintToken(ConstraintToken::ConstraintTokenKind::GREATER),
               1};
     case '<':
-      if (Str.startswith("<->") || Str.startswith("<=>")) {
+      if (legacy::starts_with(Str, "<->") || legacy::starts_with(Str, "<=>")) {
         return {
             ConstraintToken(ConstraintToken::ConstraintTokenKind::EQUIVALENT),
             3};
-      } else if (Str.startswith("<=")) {
+      } else if (legacy::starts_with(Str, "<=")) {
         return {
             ConstraintToken(ConstraintToken::ConstraintTokenKind::LESS_EQUAL),
             2};
@@ -282,7 +294,7 @@ static int64_t parseInteger(llvm::StringRef Str,
   }
 
   // If parsing failed, we return minimal or maximal value respectively.
-  if (Str.startswith("-")) {
+  if (legacy::starts_with(Str, "-")) {
     return std::numeric_limits<int64_t>::min();
   }
   return std::numeric_limits<int64_t>::max();

--- a/include/vara/Feature/FeatureSourceRange.h
+++ b/include/vara/Feature/FeatureSourceRange.h
@@ -1,8 +1,6 @@
 #ifndef VARA_FEATURE_FEATURESOURCERANGE_H
 #define VARA_FEATURE_FEATURESOURCERANGE_H
 
-#include "llvm/ADT/None.h"
-#include "llvm/ADT/Optional.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/Support/FormatVariadic.h"
 
@@ -17,7 +15,6 @@ namespace fs = std::experimental::filesystem;
 #include <optional>
 #include <sstream>
 #include <string>
-#include <tuple>
 #include <utility>
 
 namespace vara::feature {

--- a/tools/fm-viewer/FeatureModelViewer.cpp
+++ b/tools/fm-viewer/FeatureModelViewer.cpp
@@ -6,6 +6,8 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Program.h"
 
+#include <optional>
+
 static llvm::cl::OptionCategory
     FMViewerCategory("Feature model viewer options");
 
@@ -80,7 +82,12 @@ int main(int Argc, char **Argv) {
             Viewer.empty() ? llvm::errc::invalid_argument
                            : llvm::sys::findProgramByName(Viewer)) {
       llvm::errs() << "Trying '" << *P << "' program... \n";
+#if __has_include("llvm/ADT/Optional.h")
+      // To stay compatible with older llvm versions
       llvm::sys::ExecuteNoWait(*P, {*P, Filename}, llvm::None);
+#else
+      llvm::sys::ExecuteNoWait(*P, {*P, Filename}, std::nullopt);
+#endif
     } else {
       llvm::DisplayGraph(Filename);
     }


### PR DESCRIPTION
Removes dependence on `llvm::Optional` which has been removed from LLVM. 