### PR TITLE
Update CI setup to run a modern compiler in addition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,13 +14,10 @@ jobs:
       matrix:
         build: [Debug, Release]
         llvm-major: [14]
-        compiler: [clang++-14, clang++-15, g++-9]
+        compiler: [clang++-14, clang++-19, g++-9]
         include:
           - llvm-major: 14
             llvm-minor: 0
-        exclude:
-          - llvm-major: 14
-            compiler: clang++-15
 
     continue-on-error: false
     steps:
@@ -53,9 +50,9 @@ jobs:
         run: |
           sudo apt-key adv --fetch-keys https://apt.llvm.org/llvm-snapshot.gpg.key
           sudo add-apt-repository -y 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main'
-          sudo add-apt-repository -y 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-15 main'
+          sudo add-apt-repository -y 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-19 main'
           sudo apt-get update
-          sudo apt-get -y install --no-install-recommends clang-${{ matrix.llvm-major }} llvm-${{ matrix.llvm-major }}-dev clang-tidy-14
+          sudo apt-get -y install --no-install-recommends clang-${{ matrix.llvm-major }} llvm-${{ matrix.llvm-major }}-dev clang-tidy-19
 
       - name: Workaround for sanitizer
         shell: bash
@@ -71,9 +68,13 @@ jobs:
           CXX: ${{ matrix.compiler }}
         shell: bash
         run: |
+          echo $CXX
+          $CXX -std=c++17 file.cpp
+          ls
           mkdir build
           cd build
           cmake .. \
+            --debug-trycompile \
             -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
             -DLLVM_REQUESTED_VERSION=$LLVM_VERSION \
             -DCMAKE_CXX_COMPILER=$CXX \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,11 +119,11 @@ endif()
 
 find_program(
   VARA_FEATURE_RUN_CLANG_TIDY
-  NAMES run-clang-tidy-14.py
-        run-clang-tidy-14
+  NAMES run-clang-tidy-19.py
+        run-clang-tidy-19
         run-clang-tidy.py
         run-clang-tidy
-        clang-tidy-14
+        clang-tidy-19
         clang-tidy
   PATHS /usr/bin/ /usr/lib/llvm/*/share/clang/
 )

--- a/cmake/vara_feature_macros.cmake
+++ b/cmake/vara_feature_macros.cmake
@@ -99,7 +99,8 @@ function(check_std_filesystems varname)
   set(CMAKE_REQUIRED_FLAGS "-std=c++17 ${CMAKE_REQUIRED_FLAGS}")
   set(CMAKE_REQUIRED_QUIET FALSE)
   message(STATUS "Args: ${CMAKE_REQUIRED_FLAGS}")
-  check_cxx_source_compiles("
+  check_cxx_source_compiles(
+    "
 #include <filesystem>
 namespace fs = std::filesystem;
 int main() { return 0; }

--- a/cmake/vara_feature_macros.cmake
+++ b/cmake/vara_feature_macros.cmake
@@ -97,8 +97,9 @@ endif()
 function(check_std_filesystems varname)
   set(old_cmake_required_flags ${CMAKE_REQUIRED_FLAGS})
   set(CMAKE_REQUIRED_FLAGS "-std=c++17 ${CMAKE_REQUIRED_FLAGS}")
-  check_cxx_source_compiles(
-    "
+  set(CMAKE_REQUIRED_QUIET FALSE)
+  message(STATUS "Args: ${CMAKE_REQUIRED_FLAGS}")
+  check_cxx_source_compiles("
 #include <filesystem>
 namespace fs = std::filesystem;
 int main() { return 0; }

--- a/file.cpp
+++ b/file.cpp
@@ -1,0 +1,4 @@
+
+#include <filesystem>
+namespace fs = std::filesystem;
+int main() { return 0; }


### PR DESCRIPTION
In addition to out checks for older compilers (to support older systems), we should also use a new compiler to profit from extra checks and ensure we stay compatible to updated compiler versions.